### PR TITLE
Protection policy acceptance test added

### DIFF
--- a/powerstore/resource_protection_policy_test.go
+++ b/powerstore/resource_protection_policy_test.go
@@ -21,10 +21,10 @@ func TestAccProtectionPolicy_Create(t *testing.T) {
 			{
 				Config: ProtectionPolicyParamsCreate,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "name", "protectionpolicy_acc_new"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "description", "Test CreateProtectionPolicy"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "replication_rule_ids.*", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "snapshot_rule_ids.*", "153df6eb-3433-4b5e-942e-ecf90348df20"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "name", "protectionpolicy_acc_new"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "description", "Test CreateProtectionPolicy"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_ids.*", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.*", "153df6eb-3433-4b5e-942e-ecf90348df20"),
 				),
 			},
 		},
@@ -44,19 +44,19 @@ func TestAccProtectionPolicy_Update(t *testing.T) {
 			{
 				Config: ProtectionPolicyParamsCreate,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "name", "protectionpolicy_acc_new"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "description", "Test CreateProtectionPolicy"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "replication_rule_ids.*", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "snapshot_rule_ids.*", "153df6eb-3433-4b5e-942e-ecf90348df20"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "name", "protectionpolicy_acc_new"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "description", "Test CreateProtectionPolicy"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_ids.*", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.*", "153df6eb-3433-4b5e-942e-ecf90348df20"),
 				),
 			},
 			{
 				Config: ProtectionPolicyParamsUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "name", "protectionpolicy_acc_new"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "description", "Test UpdateProtectionPolicy"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "replication_rule_ids.*", "5520daa7-aedb-4966-93c5-f0ae82b040ee"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "snapshot_rule_ids.*", "4be81573-c0e6-4956-a32f-a0e396a9b86d"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "name", "protectionpolicy_acc_new"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "description", "Test UpdateProtectionPolicy"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_ids.*", "5520daa7-aedb-4966-93c5-f0ae82b040ee"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.*", "4be81573-c0e6-4956-a32f-a0e396a9b86d"),
 				),
 			},
 		},
@@ -145,7 +145,7 @@ provider "powerstore" {
 	endpoint = "` + endpoint + `"
 	insecure = true
 }
-resource "powerstore_storagecontainer" "test" {
+resource "powerstore_protectionpolicy" "test" {
 	name = "protectionpolicy_acc_new"
 	description = "Test UpdateProtectionPolicy"
 }
@@ -158,7 +158,7 @@ provider "powerstore" {
 	endpoint = "` + endpoint + `"
 	insecure = true
 }
-resource "powerstore_storagecontainer" "test" {
+resource "powerstore_protectionpolicy" "test" {
 	name = "protectionpolicy_acc_new"
 	description = "Test UpdateProtectionPolicy"
 	snapshot_rule_names = ["test_snapshotrule_1"]
@@ -172,7 +172,7 @@ provider "powerstore" {
 	endpoint = "` + endpoint + `"
 	insecure = true
 }
-resource "powerstore_storagecontainer" "test" {
+resource "powerstore_protectionpolicy" "test" {
 	name = "protectionpolicy_acc_new"
 	description = "Test UpdateProtectionPolicy"
 	replication_rule_names = ["rr-llau-csi-test2-RT-D8337-Five_Minutes"]

--- a/powerstore/resource_protection_policy_test.go
+++ b/powerstore/resource_protection_policy_test.go
@@ -1,0 +1,181 @@
+package powerstore
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Test to Create ProtectionPolicy
+func TestAccProtectionPolicy_Create(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Dont run with units tests because it will try to create the context")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: ProtectionPolicyParamsCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "name", "protectionpolicy_acc_new"),
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "description", "Test CreateProtectionPolicy"),
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "replication_rule_ids.*", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "snapshot_rule_ids.*", "153df6eb-3433-4b5e-942e-ecf90348df20"),
+				),
+			},
+		},
+	})
+}
+
+// Test to Update existing ProtectionPolicy Params
+func TestAccProtectionPolicy_Update(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Dont run with units tests because it will try to create the context")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: ProtectionPolicyParamsCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "name", "protectionpolicy_acc_new"),
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "description", "Test CreateProtectionPolicy"),
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "replication_rule_ids.*", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "snapshot_rule_ids.*", "153df6eb-3433-4b5e-942e-ecf90348df20"),
+				),
+			},
+			{
+				Config: ProtectionPolicyParamsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "name", "protectionpolicy_acc_new"),
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "description", "Test UpdateProtectionPolicy"),
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "replication_rule_ids.*", "5520daa7-aedb-4966-93c5-f0ae82b040ee"),
+					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "snapshot_rule_ids.*", "4be81573-c0e6-4956-a32f-a0e396a9b86d"),
+				),
+			},
+		},
+	})
+}
+
+// Test to Create ProtectionPolicy with Invalid values, will result in error
+func TestAccProtectionPolicy_CreateWithInvalidValues(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Dont run with units tests because it will try to create the context")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config:      ProtectionPoliycParamsCreateServerError,
+				ExpectError: regexp.MustCompile("Could not create protection policy"),
+			},
+		},
+	})
+}
+
+// Test to Create ProtectionPolicy with mutually exclusive params available
+func TestAccProtectionPolicy_CreateWithMutuallyExclusiveParams(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Dont run with units tests because it will try to create the context")
+	}
+
+	tests := []resource.TestStep{
+		{
+			Config:      ProtectionPolicyParamsWithSnapshotIDAndName,
+			ExpectError: regexp.MustCompile("Either of Snapshot Rule ID or Snapshot Rule Name should be present"),
+		},
+		{
+			Config:      ProtectionPolicyParamsWithReplicationIDAndName,
+			ExpectError: regexp.MustCompile("Either of Replication Rule ID or Replication Rule Name should be present"),
+		},
+	}
+
+	for i := range tests {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testProviderFactory,
+			Steps:                    []resource.TestStep{tests[i]},
+		})
+	}
+}
+
+var ProtectionPolicyParamsCreate = `
+provider "powerstore" {
+	username = "` + username + `"
+	password = "` + password + `"
+	endpoint = "` + endpoint + `"
+	insecure = true
+}
+
+resource "powerstore_protectionpolicy" "test" {
+	name = "protectionpolicy_acc_new"
+	description = "Test CreateProtectionPolicy"
+	replication_rule_ids = ["5d45b173-9a85-473e-8ab8-e107f8b8085e"]
+	snapshot_rule_ids = ["153df6eb-3433-4b5e-942e-ecf90348df20"]
+}
+`
+
+var ProtectionPolicyParamsUpdate = `
+provider "powerstore" {
+	username = "` + username + `"
+	password = "` + password + `"
+	endpoint = "` + endpoint + `"
+	insecure = true
+}
+
+resource "powerstore_protectionpolicy" "test" {
+	name = "protectionpolicy_acc_new"
+	description = "Test UpdateProtectionPolicy"
+	replication_rule_ids = ["5520daa7-aedb-4966-93c5-f0ae82b040ee"]
+	snapshot_rule_ids = ["4be81573-c0e6-4956-a32f-a0e396a9b86d"]
+}
+`
+var ProtectionPoliycParamsCreateServerError = `
+provider "powerstore" {
+	username = "` + username + `"
+	password = "` + password + `"
+	endpoint = "` + endpoint + `"
+	insecure = true
+}
+resource "powerstore_storagecontainer" "test" {
+	name = "protectionpolicy_acc_new"
+	description = "Test UpdateProtectionPolicy"
+}
+`
+
+var ProtectionPolicyParamsWithSnapshotIDAndName = `
+provider "powerstore" {
+	username = "` + username + `"
+	password = "` + password + `"
+	endpoint = "` + endpoint + `"
+	insecure = true
+}
+resource "powerstore_storagecontainer" "test" {
+	name = "protectionpolicy_acc_new"
+	description = "Test UpdateProtectionPolicy"
+	snapshot_rule_names = ["test_snapshotrule_1"]
+	snapshot_rule_ids = ["26837335-f92e-4da8-8ea7-b6e1aab7c7cf"]
+}
+`
+var ProtectionPolicyParamsWithReplicationIDAndName = `
+provider "powerstore" {
+	username = "` + username + `"
+	password = "` + password + `"
+	endpoint = "` + endpoint + `"
+	insecure = true
+}
+resource "powerstore_storagecontainer" "test" {
+	name = "protectionpolicy_acc_new"
+	description = "Test UpdateProtectionPolicy"
+	replication_rule_names = ["rr-llau-csi-test2-RT-D8337-Five_Minutes"]
+	replication_rule_ids = ["ac0a3611-bea0-4298-89ad-536e5a8788bd"]
+}
+`

--- a/powerstore/resource_protection_policy_test.go
+++ b/powerstore/resource_protection_policy_test.go
@@ -23,8 +23,8 @@ func TestAccProtectionPolicy_Create(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "name", "protectionpolicy_acc_new"),
 					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "description", "Test CreateProtectionPolicy"),
-					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_ids.*", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
-					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.*", "153df6eb-3433-4b5e-942e-ecf90348df20"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_ids.0", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.0", "4be81573-c0e6-4956-a32f-a0e396a9b86d"),
 				),
 			},
 		},
@@ -46,8 +46,8 @@ func TestAccProtectionPolicy_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "name", "protectionpolicy_acc_new"),
 					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "description", "Test CreateProtectionPolicy"),
-					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_ids.*", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
-					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.*", "153df6eb-3433-4b5e-942e-ecf90348df20"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_ids.0", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.0", "4be81573-c0e6-4956-a32f-a0e396a9b86d"),
 				),
 			},
 			{
@@ -55,8 +55,8 @@ func TestAccProtectionPolicy_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "name", "protectionpolicy_acc_new"),
 					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "description", "Test UpdateProtectionPolicy"),
-					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_ids.*", "5520daa7-aedb-4966-93c5-f0ae82b040ee"),
-					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.*", "4be81573-c0e6-4956-a32f-a0e396a9b86d"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_ids.0", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.0", "4be81573-c0e6-4956-a32f-a0e396a9b86d"),
 				),
 			},
 		},
@@ -81,6 +81,33 @@ func TestAccProtectionPolicy_CreateWithInvalidValues(t *testing.T) {
 	})
 }
 
+// Test to update existing ProtectionPolicy params but will result in error
+func TestAccProtectionPolicy_UpdateError(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Dont run with units tests because it will try to create the context")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: ProtectionPolicyParamsCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "name", "protectionpolicy_acc_new"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "description", "Test CreateProtectionPolicy"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_ids.0", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.0", "4be81573-c0e6-4956-a32f-a0e396a9b86d"),
+				),
+			},
+			{
+				Config:      ProtectionPoliycParamsCreateServerError,
+				ExpectError: regexp.MustCompile("Could not update"),
+			},
+		},
+	})
+}
+
 // Test to Create ProtectionPolicy with mutually exclusive params available
 func TestAccProtectionPolicy_CreateWithMutuallyExclusiveParams(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
@@ -90,11 +117,11 @@ func TestAccProtectionPolicy_CreateWithMutuallyExclusiveParams(t *testing.T) {
 	tests := []resource.TestStep{
 		{
 			Config:      ProtectionPolicyParamsWithSnapshotIDAndName,
-			ExpectError: regexp.MustCompile("Either of Snapshot Rule ID or Snapshot Rule Name should be present"),
+			ExpectError: regexp.MustCompile("either of snapshot rule id or snapshot rule name should be present"),
 		},
 		{
 			Config:      ProtectionPolicyParamsWithReplicationIDAndName,
-			ExpectError: regexp.MustCompile("Either of Replication Rule ID or Replication Rule Name should be present"),
+			ExpectError: regexp.MustCompile("either of replication rule id or replication rule name should be present"),
 		},
 	}
 
@@ -107,6 +134,52 @@ func TestAccProtectionPolicy_CreateWithMutuallyExclusiveParams(t *testing.T) {
 	}
 }
 
+// Test to Create ProtectionPolicy with SnapshotRule Name
+func TestAccProtectionPolicy_CreateWithSnapshotRuleName(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Dont run with units tests because it will try to create the context")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: ProtectionPolicyParamsWithSnapshotRuleName,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "name", "protectionpolicy_acc_new"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "description", "Test CreateProtectionPolicy"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_names.0", "test_snapshotrule_1"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_ids.0", "5d45b173-9a85-473e-8ab8-e107f8b8085e"),
+				),
+			},
+		},
+	})
+}
+
+// Test to Create ProtectionPolicy with ReplicationRule Name
+func TestAccProtectionPolicy_CreateWithReplicationRuleName(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Dont run with units tests because it will try to create the context")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testProviderFactory,
+		Steps: []resource.TestStep{
+			{
+				Config: ProtectionPolicyParamsWithReplicationRuleName,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "name", "protectionpolicy_acc_new"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "description", "Test CreateProtectionPolicy"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.0", "4be81573-c0e6-4956-a32f-a0e396a9b86d"),
+					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "replication_rule_names.0", "Emalee-SRA-7416-Rep"),
+				),
+			},
+		},
+	})
+}
+
 var ProtectionPolicyParamsCreate = `
 provider "powerstore" {
 	username = "` + username + `"
@@ -114,12 +187,11 @@ provider "powerstore" {
 	endpoint = "` + endpoint + `"
 	insecure = true
 }
-
 resource "powerstore_protectionpolicy" "test" {
 	name = "protectionpolicy_acc_new"
 	description = "Test CreateProtectionPolicy"
 	replication_rule_ids = ["5d45b173-9a85-473e-8ab8-e107f8b8085e"]
-	snapshot_rule_ids = ["153df6eb-3433-4b5e-942e-ecf90348df20"]
+	snapshot_rule_ids = ["4be81573-c0e6-4956-a32f-a0e396a9b86d"]
 }
 `
 
@@ -130,14 +202,14 @@ provider "powerstore" {
 	endpoint = "` + endpoint + `"
 	insecure = true
 }
-
 resource "powerstore_protectionpolicy" "test" {
 	name = "protectionpolicy_acc_new"
 	description = "Test UpdateProtectionPolicy"
-	replication_rule_ids = ["5520daa7-aedb-4966-93c5-f0ae82b040ee"]
+	replication_rule_ids = ["5d45b173-9a85-473e-8ab8-e107f8b8085e"]
 	snapshot_rule_ids = ["4be81573-c0e6-4956-a32f-a0e396a9b86d"]
 }
 `
+
 var ProtectionPoliycParamsCreateServerError = `
 provider "powerstore" {
 	username = "` + username + `"
@@ -162,9 +234,10 @@ resource "powerstore_protectionpolicy" "test" {
 	name = "protectionpolicy_acc_new"
 	description = "Test UpdateProtectionPolicy"
 	snapshot_rule_names = ["test_snapshotrule_1"]
-	snapshot_rule_ids = ["26837335-f92e-4da8-8ea7-b6e1aab7c7cf"]
+	snapshot_rule_ids = ["4be81573-c0e6-4956-a32f-a0e396a9b86d"]
 }
 `
+
 var ProtectionPolicyParamsWithReplicationIDAndName = `
 provider "powerstore" {
 	username = "` + username + `"
@@ -175,7 +248,37 @@ provider "powerstore" {
 resource "powerstore_protectionpolicy" "test" {
 	name = "protectionpolicy_acc_new"
 	description = "Test UpdateProtectionPolicy"
-	replication_rule_names = ["rr-llau-csi-test2-RT-D8337-Five_Minutes"]
-	replication_rule_ids = ["ac0a3611-bea0-4298-89ad-536e5a8788bd"]
+	replication_rule_names = ["Emalee-SRA-7416-Rep"]
+	replication_rule_ids = ["5d45b173-9a85-473e-8ab8-e107f8b8085e"]
+}
+`
+
+var ProtectionPolicyParamsWithSnapshotRuleName = `
+provider "powerstore" {
+	username = "` + username + `"
+	password = "` + password + `"
+	endpoint = "` + endpoint + `"
+	insecure = true
+}
+resource "powerstore_protectionpolicy" "test" {
+	name = "protectionpolicy_acc_new"
+	description = "Test CreateProtectionPolicy"
+	snapshot_rule_names = ["test_snapshotrule_1"]
+	replication_rule_ids = ["5d45b173-9a85-473e-8ab8-e107f8b8085e"]
+}
+`
+
+var ProtectionPolicyParamsWithReplicationRuleName = `
+provider "powerstore" {
+	username = "` + username + `"
+	password = "` + password + `"
+	endpoint = "` + endpoint + `"
+	insecure = true
+}
+resource "powerstore_protectionpolicy" "test" {
+	name = "protectionpolicy_acc_new"
+	description = "Test CreateProtectionPolicy"
+	snapshot_rule_ids = ["4be81573-c0e6-4956-a32f-a0e396a9b86d"]
+	replication_rule_names = ["Emalee-SRA-7416-Rep"]
 }
 `


### PR DESCRIPTION
# Description

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
```
# TF_ACC=1 go test -coverprofile=coverage.out ./... -v -run TestAccProtectionPolicy
?       terraform-provider-powerstore   [no test files]
?       terraform-provider-powerstore/client    [no test files]
?       terraform-provider-powerstore/models    [no test files]
=== RUN   TestAccProtectionPolicy_Create
--- PASS: TestAccProtectionPolicy_Create (2.11s)
=== RUN   TestAccProtectionPolicy_Update
--- PASS: TestAccProtectionPolicy_Update (3.91s)
=== RUN   TestAccProtectionPolicy_CreateWithInvalidValues
--- PASS: TestAccProtectionPolicy_CreateWithInvalidValues (0.81s)
=== RUN   TestAccProtectionPolicy_UpdateError
--- PASS: TestAccProtectionPolicy_UpdateError (3.18s)
=== RUN   TestAccProtectionPolicy_InvalidUpdate
--- PASS: TestAccProtectionPolicy_InvalidUpdate (3.12s)
=== RUN   TestAccProtectionPolicy_CreateWithMutuallyExclusiveParams
--- PASS: TestAccProtectionPolicy_CreateWithMutuallyExclusiveParams (1.33s)
=== RUN   TestAccProtectionPolicy_CreateWithSnapshotRuleName
--- PASS: TestAccProtectionPolicy_CreateWithSnapshotRuleName (3.63s)
=== RUN   TestAccProtectionPolicy_CreateWithReplicationRuleName
--- PASS: TestAccProtectionPolicy_CreateWithReplicationRuleName (2.24s)
PASS
coverage: 22.4% of statements

```
**Coverage:**
> 
terraform-provider-powerstore/powerstore/resource_protection_policy.go (86.9%)