### PR TITLE
Fixed snapshot rule issue with time_of_day_attribute

### DIFF
--- a/powerstore/resource_snapshotrule.go
+++ b/powerstore/resource_snapshotrule.go
@@ -248,6 +248,9 @@ func (r *resourceSnapshotRule) Schema(ctx context.Context, req resource.SchemaRe
 							string(gopowerstore.DaysOfWeekEnumSunday),
 						}...),
 					),
+					listvalidator.AlsoRequires(path.Expressions{
+						path.MatchRoot("time_of_day"),
+					}...),
 				},
 			},
 

--- a/powerstore/resource_snapshotrule.go
+++ b/powerstore/resource_snapshotrule.go
@@ -92,9 +92,6 @@ func (r *resourceSnapshotRule) Schema(ctx context.Context, req resource.SchemaRe
 				Description:         "The time of the day to take a daily snapshot, with format hh:mm, mutually exclusive with interval parameter.",
 				MarkdownDescription: "The time of the day to take a daily snapshot, with format hh:mm.",
 				Validators: []validator.String{
-					stringvalidator.ExactlyOneOf(path.Expressions{
-						path.MatchRoot("interval"),
-					}...),
 
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(`^[0-9]{2}:[0-9]{2}$`),

--- a/powerstore/resource_snapshotrule.go
+++ b/powerstore/resource_snapshotrule.go
@@ -245,9 +245,6 @@ func (r *resourceSnapshotRule) Schema(ctx context.Context, req resource.SchemaRe
 							string(gopowerstore.DaysOfWeekEnumSunday),
 						}...),
 					),
-					listvalidator.AlsoRequires(path.Expressions{
-						path.MatchRoot("time_of_day"),
-					}...),
 				},
 			},
 


### PR DESCRIPTION
[TFM-368](https://jira.cec.lab.emc.com/browse/TFM-368)
# Description
Snapshot rule: error message is not clear for "Create snapshot rule without time_of_day but with days_of_week"
Removed validator which is not required for the  "time_of_the_day" attribute
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Acceptance tests

```
?       terraform-provider-powerstore   [no test files]
?       terraform-provider-powerstore/client    [no test files]
?       terraform-provider-powerstore/models    [no test files]
=== RUN   TestAccSnapshotRule_CreateSnapShotRule
--- PASS: TestAccSnapshotRule_CreateSnapShotRule (4.79s)
=== RUN   TestAccSnapshotRule_UpdateSnapShotRule
--- PASS: TestAccSnapshotRule_UpdateSnapShotRule (4.17s)
=== RUN   TestAccSnapshotRule_CreateSnapShotRuleWithInvalidValues
--- PASS: TestAccSnapshotRule_CreateSnapShotRuleWithInvalidValues (0.94s)
=== RUN   TestAccSnapshotRule_ImportFailure
--- PASS: TestAccSnapshotRule_ImportFailure (0.43s)
=== RUN   TestAccSnapshotRule_ImportSuccess
--- PASS: TestAccSnapshotRule_ImportSuccess (2.91s)
PASS
coverage: 16.7% of statements
ok      terraform-provider-powerstore/powerstore        13.256s coverage: 16.7% of statements

```