### PR TITLE
Fixed Protection policy error with replication_rule attributes

### DIFF
--- a/powerstore/resource_protection_policy.go
+++ b/powerstore/resource_protection_policy.go
@@ -90,12 +90,12 @@ func (r *resourceProtectionPolicy) Schema(ctx context.Context, req resource.Sche
 				Description:         "List of the snapshot rule IDs that are associated with this policy.",
 				MarkdownDescription: "List of the snapshot rule IDs that are associated with this policy.",
 				Validators: []validator.Set{
-
-					setvalidator.SizeAtLeast(1),
-
 					setvalidator.ValueStringsAre(
 						stringvalidator.LengthAtLeast(1),
 					),
+					setvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot("snapshot_rule_names"),
+					}...),
 				},
 			},
 
@@ -106,9 +106,6 @@ func (r *resourceProtectionPolicy) Schema(ctx context.Context, req resource.Sche
 				Description:         "List of the snapshot rule names that are associated with this policy.",
 				MarkdownDescription: "List of the snapshot rule names that are associated with this policy.",
 				Validators: []validator.Set{
-
-					setvalidator.SizeAtLeast(1),
-
 					setvalidator.ValueStringsAre(
 						stringvalidator.LengthAtLeast(1),
 					),
@@ -122,12 +119,12 @@ func (r *resourceProtectionPolicy) Schema(ctx context.Context, req resource.Sche
 				Description:         "List of the replication rule IDs that are associated with this policy.",
 				MarkdownDescription: "List of the replication rule IDs that are associated with this policy.",
 				Validators: []validator.Set{
-
-					setvalidator.SizeAtLeast(1),
-
 					setvalidator.ValueStringsAre(
 						stringvalidator.LengthAtLeast(1),
 					),
+					setvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot("replication_rule_names"),
+					}...),
 				},
 			},
 
@@ -138,9 +135,6 @@ func (r *resourceProtectionPolicy) Schema(ctx context.Context, req resource.Sche
 				Description:         "List of the replication rule names that are associated with this policy.",
 				MarkdownDescription: "List of the replication rule names that are associated with this policy.",
 				Validators: []validator.Set{
-
-					setvalidator.SizeAtLeast(1),
-
 					setvalidator.ValueStringsAre(
 						stringvalidator.LengthAtLeast(1),
 					),

--- a/powerstore/resource_protection_policy_test.go
+++ b/powerstore/resource_protection_policy_test.go
@@ -119,11 +119,11 @@ func TestAccProtectionPolicy_CreateWithMutuallyExclusiveParams(t *testing.T) {
 	tests := []resource.TestStep{
 		{
 			Config:      ProtectionPolicyParamsWithSnapshotIDAndName,
-			ExpectError: regexp.MustCompile("either of snapshot rule id or snapshot rule name should be present"),
+			ExpectError: regexp.MustCompile("Invalid Attribute Combination"),
 		},
 		{
 			Config:      ProtectionPolicyParamsWithReplicationIDAndName,
-			ExpectError: regexp.MustCompile("either of replication rule id or replication rule name should be present"),
+			ExpectError: regexp.MustCompile("Invalid Attribute Combination"),
 		},
 	}
 


### PR DESCRIPTION
# Description
Protection policy: removal of replication rule in modify failing.

Modified validators to handle mutually exclusive attrinutes

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Acceptance tests

```
?       terraform-provider-powerstore   [no test files]
?       terraform-provider-powerstore/client    [no test files]
?       terraform-provider-powerstore/models    [no test files]
=== RUN   TestAccProtectionPolicy_Create
--- PASS: TestAccProtectionPolicy_Create (2.31s)
=== RUN   TestAccProtectionPolicy_Update
--- PASS: TestAccProtectionPolicy_Update (4.78s)
=== RUN   TestAccProtectionPolicy_CreateWithInvalidValues
--- PASS: TestAccProtectionPolicy_CreateWithInvalidValues (0.94s)
=== RUN   TestAccProtectionPolicy_UpdateError
--- PASS: TestAccProtectionPolicy_UpdateError (3.17s)
=== RUN   TestAccProtectionPolicy_CreateWithMutuallyExclusiveParams
--- PASS: TestAccProtectionPolicy_CreateWithMutuallyExclusiveParams (0.47s)
=== RUN   TestAccProtectionPolicy_CreateWithSnapshotRuleName
--- PASS: TestAccProtectionPolicy_CreateWithSnapshotRuleName (2.62s)
=== RUN   TestAccProtectionPolicy_CreateWithReplicationRuleName
--- PASS: TestAccProtectionPolicy_CreateWithReplicationRuleName (2.41s)
=== RUN   TestAccProtectionPolicy_ImportFailure
--- PASS: TestAccProtectionPolicy_ImportFailure (0.48s)
=== RUN   TestAccProtectionPolicy_ImportSuccess
--- PASS: TestAccProtectionPolicy_ImportSuccess (2.81s)
PASS
coverage: 21.1% of statements
ok      terraform-provider-powerstore/powerstore        20.005s coverage: 21.1% of statements

```