### PR TITLE
Detaching volumes and protection policy from volume group

### DIFF
--- a/powerstore/resource_volume_group.go
+++ b/powerstore/resource_volume_group.go
@@ -198,6 +198,21 @@ func (r *resourceVolumeGroup) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
+	//Remove protection policy from volume group if present
+	if volGroupResponse.ProtectionPolicyID != "" {
+		volGroupChangePolicy := &gopowerstore.VolumeGroupChangePolicy{
+			ProtectionPolicyID: "",
+		}
+		_, err = r.client.PStoreClient.UpdateVolumeGroupProtectionPolicy(context.Background(), volumeGroupID, volGroupChangePolicy)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error deleting volume group",
+				"Could not remove protection policy from volume group "+volumeGroupID+": "+err.Error(),
+			)
+			return
+		}
+	}
+
 	//Remove volume(s) from volume group if present
 	if len(volGroupResponse.Volumes) != 0 {
 		var volumeIDs []string
@@ -212,21 +227,6 @@ func (r *resourceVolumeGroup) Delete(ctx context.Context, req resource.DeleteReq
 			resp.Diagnostics.AddError(
 				"Error deleting volume group",
 				"Could not remove volume from volume group "+volumeGroupID+": "+err.Error(),
-			)
-			return
-		}
-	}
-
-	//Remove protection policy from volume group if present
-	if volGroupResponse.ProtectionPolicyID != "" {
-		volGroupChangePolicy := &gopowerstore.VolumeGroupChangePolicy{
-			ProtectionPolicyID: "",
-		}
-		_, err = r.client.PStoreClient.UpdateVolumeGroupProtectionPolicy(context.Background(), volumeGroupID, volGroupChangePolicy)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error deleting volume group",
-				"Could not remove protection policy from volume group "+volumeGroupID+": "+err.Error(),
 			)
 			return
 		}

--- a/powerstore/resource_volume_group.go
+++ b/powerstore/resource_volume_group.go
@@ -188,8 +188,52 @@ func (r *resourceVolumeGroup) Delete(ctx context.Context, req resource.DeleteReq
 	//Get Volume Group ID from state
 	volumeGroupID := state.ID.ValueString()
 
+	//Get Volume Group details using ID retrived above
+	volGroupResponse, err := r.client.PStoreClient.GetVolumeGroup(context.Background(), volumeGroupID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error getting volume group after creation",
+			"Could not get volume group, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	//Remove volume(s) from volume group if present
+	if len(volGroupResponse.Volumes) != 0 {
+		var volumeIDs []string
+		for _, vol := range volGroupResponse.Volumes {
+			volumeIDs = append(volumeIDs, vol.ID)
+		}
+		volGroupMembers := &gopowerstore.VolumeGroupMembers{
+			VolumeIds: volumeIDs,
+		}
+		_, err = r.client.PStoreClient.RemoveMembersFromVolumeGroup(context.Background(), volGroupMembers, volumeGroupID)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error deleting volume group",
+				"Could not remove volume from volume group "+volumeGroupID+": "+err.Error(),
+			)
+			return
+		}
+	}
+
+	//Remove protection policy from volume group if present
+	if volGroupResponse.ProtectionPolicyID != "" {
+		volGroupChangePolicy := &gopowerstore.VolumeGroupChangePolicy{
+			ProtectionPolicyID: "",
+		}
+		_, err = r.client.PStoreClient.UpdateVolumeGroupProtectionPolicy(context.Background(), volumeGroupID, volGroupChangePolicy)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error deleting volume group",
+				"Could not remove protection policy from volume group "+volumeGroupID+": "+err.Error(),
+			)
+			return
+		}
+	}
+
 	//Delete Volume Group by calling API
-	_, err := r.client.PStoreClient.DeleteVolumeGroup(context.Background(), volumeGroupID)
+	_, err = r.client.PStoreClient.DeleteVolumeGroup(context.Background(), volumeGroupID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting volume group",


### PR DESCRIPTION
# Description
Removing volumes and detaching protection policy from volume group as it is a prerequisite to destroy the resource. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Acceptance tests