### PR TITLE
Added naming support for volumes and protection policy

### DIFF
--- a/models/volumegroup.go
+++ b/models/volumegroup.go
@@ -12,4 +12,6 @@ type Volumegroup struct {
 	VolumeIDs              types.Set    `tfsdk:"volume_ids"`
 	IsWriteOrderConsistent types.Bool   `tfsdk:"is_write_order_consistent"`
 	ProtectionPolicyID     types.String `tfsdk:"protection_policy_id"`
+	VolumeNames            types.Set    `tfsdk:"volume_names"`
+	ProtectionPolicyName   types.String `tfsdk:"protection_policy_name"`
 }

--- a/powerstore/resource_volume_group.go
+++ b/powerstore/resource_volume_group.go
@@ -2,6 +2,7 @@ package powerstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -76,6 +78,9 @@ func (r *resourceVolumeGroup) Schema(ctx context.Context, req resource.SchemaReq
 					setvalidator.ValueStringsAre(
 						stringvalidator.LengthAtLeast(1),
 					),
+					setvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot("volume_names"),
+					}...),
 				},
 			},
 
@@ -91,6 +96,32 @@ func (r *resourceVolumeGroup) Schema(ctx context.Context, req resource.SchemaReq
 				Computed:            true,
 				Description:         "Unique identifier of the protection policy assigned to the volume group.",
 				MarkdownDescription: "Unique identifier of the protection policy assigned to the volume group.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+					stringvalidator.ConflictsWith(path.Expressions{
+						path.MatchRoot("protection_policy_name"),
+					}...),
+				},
+			},
+
+			"volume_names": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Computed:            true,
+				Description:         "A list of names of existing volumes that should be added to the volume group.",
+				MarkdownDescription: "A list of names of existing volumes that should be added to the volume group.",
+				Validators: []validator.Set{
+					setvalidator.ValueStringsAre(
+						stringvalidator.LengthAtLeast(1),
+					),
+				},
+			},
+
+			"protection_policy_name": schema.StringAttribute{
+				Optional:            true,
+				Computed:            true,
+				Description:         "Unique name of the protection policy assigned to the volume group.",
+				MarkdownDescription: "Unique name of the protection policy assigned to the volume group.",
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
 				},
@@ -127,6 +158,16 @@ func (r *resourceVolumeGroup) Create(ctx context.Context, req resource.CreateReq
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	//Get IDs for volume and protection policy names
+	valid, err := r.fetchByName(&plan)
+	if !valid {
+		resp.Diagnostics.AddError(
+			"Error creating volume group",
+			"Could not create volume group, unexpected error: "+err.Error(),
+		)
 		return
 	}
 
@@ -257,4 +298,50 @@ func (r resourceVolumeGroup) updateVolGroupState(volgroupState *models.Volumegro
 		volumeIDList = append(volumeIDList, types.StringValue(string(volumeID)))
 	}
 	volgroupState.VolumeIDs, _ = types.SetValue(types.StringType, volumeIDList)
+
+	//Update VolumeNames value from Plan to State
+	var volumeNames []string
+	for _, volumeName := range volGroupPlan.VolumeNames.Elements() {
+		volumeNames = append(volumeNames, strings.Trim(volumeName.String(), "\""))
+	}
+	volumeNameList := []attr.Value{}
+	for _, volumeName := range volumeNames {
+		volumeNameList = append(volumeNameList, types.StringValue(string(volumeName)))
+	}
+	volgroupState.VolumeNames, _ = types.SetValue(types.StringType, volumeNameList)
+
+	//Update ProtectionPolicyName value from Plan to State
+	volgroupState.ProtectionPolicyName = volGroupPlan.ProtectionPolicyName
+}
+
+func (r resourceVolumeGroup) fetchByName(plan *models.Volumegroup) (valid bool, err error) {
+	var volumeIds []string
+	if len(plan.VolumeIDs.Elements()) != 0 && len(plan.VolumeNames.Elements()) != 0 {
+		return false, errors.New("either of volume id or volume name should be present")
+	} else if len(plan.VolumeNames.Elements()) != 0 {
+		for _, volumeName := range plan.VolumeNames.Elements() {
+			volume, err := r.client.PStoreClient.GetVolumeByName(context.Background(), strings.Trim(volumeName.String(), "\""))
+			if err != nil {
+				return false, errors.New("invalid volume name")
+			}
+			volumeIds = append(volumeIds, strings.Trim(volume.ID, "\""))
+		}
+		volumeList := []attr.Value{}
+		for i := 0; i < len(volumeIds); i++ {
+			volumeList = append(volumeList, types.StringValue(string(volumeIds[i])))
+		}
+		plan.VolumeIDs, _ = types.SetValue(types.StringType, volumeList)
+	}
+
+	if plan.ProtectionPolicyID.ValueString() != "" && plan.ProtectionPolicyName.ValueString() != "" {
+		return false, errors.New("either of protection policy id or protection policy name should be present")
+	} else if plan.ProtectionPolicyName.String() != "" {
+		policy, err := r.client.PStoreClient.GetProtectionPolicyByName(context.Background(), plan.ProtectionPolicyName.ValueString())
+		if err != nil {
+			return false, errors.New("invalid protection policy name")
+		}
+		plan.ProtectionPolicyID = types.StringValue(policy.ID)
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
# Description
Added two new attributes to volume group schema "volume_names" and "protection_policy_names" which can take names of volumes and protection policy respectively.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Acceptance tests