### PR TITLE
Fixed volume group blank description issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module terraform-provider-powerstore
 go 1.19
 
 require (
-	github.com/dell/gopowerstore v1.11.1-0.20230522093128-f74526e851f8
+	github.com/dell/gopowerstore v1.11.1-0.20230524104854-b3febafc8ade
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.1.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dell/gopowerstore v1.11.1-0.20230522093128-f74526e851f8 h1:p7B0OrtKoahT+ciFTdpUNOA4jjY/Ax/xGjFJWIFpZT8=
-github.com/dell/gopowerstore v1.11.1-0.20230522093128-f74526e851f8/go.mod h1:d5OP8ZaRcZ65GTkUuZHLGa0IFgRdA3vF4i6JccfHBYE=
+github.com/dell/gopowerstore v1.11.1-0.20230524104854-b3febafc8ade h1:Lq/4WOTmhGdFQnLkksytOeKQXQNd1L5kOpLFwkGnaus=
+github.com/dell/gopowerstore v1.11.1-0.20230524104854-b3febafc8ade/go.mod h1:d5OP8ZaRcZ65GTkUuZHLGa0IFgRdA3vF4i6JccfHBYE=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/powerstore/resource_volume_group.go
+++ b/powerstore/resource_volume_group.go
@@ -62,9 +62,6 @@ func (r *resourceVolumeGroup) Schema(ctx context.Context, req resource.SchemaReq
 				Computed:            true,
 				Description:         "Description for the volume group.",
 				MarkdownDescription: "Description for the volume group.",
-				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(1),
-				},
 			},
 
 			"volume_ids": schema.SetAttribute{


### PR DESCRIPTION
# Description
Fixed issue while creating/updating volume group resource with blank description.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Test to update description to blank
[update_volume_group_with_blank_description.txt](https://github.com/dell/terraform-provider-powerstore/files/11553895/update_volume_group_with_blank_description.txt)
