### PR TITLE
Fixed ModifyPlan issue with host group

### DIFF
--- a/powerstore/resource_host_group.go
+++ b/powerstore/resource_host_group.go
@@ -138,11 +138,11 @@ func (r *resourceHostGroup) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	valid, errmsg := r.fetchByName(&plan)
-	if !valid {
+	errmsg := r.fetchByName(&plan)
+	if errmsg != "" {
 		resp.Diagnostics.AddError(
 			"Error creating host group",
-			"Could not create host group, unexpected error: "+errmsg+"",
+			"Could not create host group, unexpected error: "+errmsg,
 		)
 		return
 	}
@@ -260,11 +260,11 @@ func (r *resourceHostGroup) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	valid, errmsg := r.fetchByName(&plan)
-	if !valid {
+	errmsg := r.fetchByName(&plan)
+	if errmsg != "" {
 		resp.Diagnostics.AddError(
 			"Error updating host group",
-			"Could not update host group, unexpected error: "+errmsg+"",
+			"Could not update host group, unexpected error: "+errmsg,
 		)
 		return
 	}
@@ -430,13 +430,13 @@ func GetHostDetails(plan models.HostGroup, state *models.HostGroup) ([]string, [
 }
 
 // fetchByName fetches hosts using name and updates respective ids in plan
-func (r resourceHostGroup) fetchByName(plan *models.HostGroup) (bool, string) {
+func (r resourceHostGroup) fetchByName(plan *models.HostGroup) string {
 	var hostIds []string
 	if len(plan.HostNames.Elements()) != 0 {
 		for _, hostName := range plan.HostNames.Elements() {
 			host, err := r.client.PStoreClient.GetHostByName(context.Background(), strings.Trim(hostName.String(), "\""))
 			if err != nil {
-				return false, "Error getting host with name: " + strings.Trim(hostName.String(), "\"")
+				return "Error getting host with name: " + strings.Trim(hostName.String(), "\"")
 			}
 			hostIds = append(hostIds, strings.Trim(host.ID, "\""))
 		}
@@ -447,5 +447,5 @@ func (r resourceHostGroup) fetchByName(plan *models.HostGroup) (bool, string) {
 		plan.HostIDs, _ = types.SetValue(types.StringType, hostList)
 	}
 
-	return true, ""
+	return ""
 }

--- a/powerstore/resource_host_group_test.go
+++ b/powerstore/resource_host_group_test.go
@@ -109,7 +109,7 @@ func TestAccHostGroup_CreateWithHostName(t *testing.T) {
 }
 
 // Test to Create HostGroup with invalid host name, will result in error
-func TestAccVolumeGroup_CreateWithInvalidHostName(t *testing.T) {
+func TestAccHostGroup_CreateWithInvalidHostName(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Dont run with units tests because it will try to create the context")
 	}


### PR DESCRIPTION
# Description
If we are creating a host and using its name as `host_names` to create a host group resource at the same time i.e creating a dependency for creation of host group resource, there was a issue in a pre-apply state as ModifyPlan is called by terraform internally to fetch host_name before applying/creating the host group.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Acceptance tests
![image](https://github.com/dell/terraform-provider-powerstore/assets/117063742/15f288eb-8789-429f-9a57-4214105463b4)
