### PR TITLE
Update Default for UTs

### DIFF
--- a/powerstore/constants.go
+++ b/powerstore/constants.go
@@ -117,6 +117,9 @@ const (
 	//CreateVolumeGroupDetailErrorMsg specifies error caused when invalid attribute values are provided
 	CreateVolumeGroupDetailErrorMsg = "Error creating volume group"
 
+	//CreateVolumeErrorMsg specifies error caused when invalid attribute values are provided
+	CreateVolumeErrorMsg = "Error creating volume"
+
 	//CreateResourceMissingErrorMsg specifies error caused when required attribute value is not provided
 	CreateResourceMissingErrorMsg = "Missing required argument"
 

--- a/powerstore/datasource_host_group_test.go
+++ b/powerstore/datasource_host_group_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Test to Fetch Host Groups
-func TestAccHostGroup_FetchHostGroup(t *testing.T) {
+func TestAccHostGroupDs_FetchHostGroup(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Dont run with units tests because it will try to create the context")
 	}

--- a/powerstore/datasource_host_test.go
+++ b/powerstore/datasource_host_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Test to Fetch Host details
-func TestAccHost_FetchHost(t *testing.T) {
+func TestAccHostDs_FetchHost(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Dont run with units tests because it will try to create the context")
 	}
@@ -49,7 +49,7 @@ func TestAccHost_FetchHost(t *testing.T) {
 }
 
 // Test to fetch Host - Negative
-func TestAccHost_FetchHostNegative(t *testing.T) {
+func TestAccHostDs_FetchHostNegative(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Dont run with units tests because it will try to create the context")
 	}

--- a/powerstore/datasource_protection_policy_test.go
+++ b/powerstore/datasource_protection_policy_test.go
@@ -26,11 +26,10 @@ import (
 )
 
 // Test to Fetch Protection Policy
-func TestAccProtectionPolicy_FetchPolicy(t *testing.T) {
+func TestAccProtectionPolicyDs_FetchPolicy(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Dont run with units tests because it will try to create the context")
 	}
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testProviderFactory,
@@ -49,7 +48,7 @@ func TestAccProtectionPolicy_FetchPolicy(t *testing.T) {
 }
 
 // Test to Fetch Protection Policy- Negative
-func TestAccProtectionPolicy_FetchPolicyNegative(t *testing.T) {
+func TestAccProtectionPolicyDs_FetchPolicyNegative(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Dont run with units tests because it will try to create the context")
 	}

--- a/powerstore/datasource_snapshotrule_test.go
+++ b/powerstore/datasource_snapshotrule_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Test to Fetch SnapshotRule
-func TestAccSnapshotRule_FetchSnapshotRule(t *testing.T) {
+func TestAccSnapshotRuleDs_FetchSnapshotRule(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Dont run with units tests because it will try to create the context")
 	}

--- a/powerstore/datasource_volume_group_snapshot_test.go
+++ b/powerstore/datasource_volume_group_snapshot_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Test to Fetch Volume Group snapshots
-func TestAccVolumeGroupSnapshot_FetchVolumeGroupSnapshot(t *testing.T) {
+func TestAccVolumeGroupSnapshotDs_FetchVolumeGroupSnapshot(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Dont run with units tests because it will try to create the context")
 	}

--- a/powerstore/datasource_volume_group_test.go
+++ b/powerstore/datasource_volume_group_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Test to Fetch Volume Groups
-func TestAccVolumeGroup_FetchVolumeGroup(t *testing.T) {
+func TestAccVolumeGroupDs_FetchVolumeGroup(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Dont run with units tests because it will try to create the context")
 	}

--- a/powerstore/datasource_volume_snapshot_test.go
+++ b/powerstore/datasource_volume_snapshot_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Test to Fetch Volume Snapshot
-func TestAccVolume_FetchVolumeSnapshot(t *testing.T) {
+func TestAccVolumeDs_FetchVolumeSnapshot(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Dont run with units tests because it will try to create the context")
 	}

--- a/powerstore/datasource_volume_test.go
+++ b/powerstore/datasource_volume_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Test to Fetch Volume
-func TestAccVolume_FetchVolume(t *testing.T) {
+func TestAccVolumeDs_FetchVolume(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("Dont run with units tests because it will try to create the context")
 	}

--- a/powerstore/provider_test.go
+++ b/powerstore/provider_test.go
@@ -30,36 +30,38 @@ import (
 // var testAccProviders map[string]func() tfsdk.Provider
 var testProvider provider.Provider
 var testProviderFactory map[string]func() (tfprotov6.ProviderServer, error)
-var endpoint = os.Getenv("POWERSTORE_ENDPOINT")
-var username = os.Getenv("POWERSTORE_USERNAME")
-var password = os.Getenv("POWERSTORE_PASSWORD")
-var hostID = os.Getenv("HOST_ID")
-var hostIDRead = os.Getenv("HOST_ID_READ")
-var hostGroupID = os.Getenv("HOST_GROUP_ID")
-var volumeGroupID = os.Getenv("VOLUME_GROUP_ID")
-var hostName = os.Getenv("HOST_NAME")
-var hostNameRead = os.Getenv("HOST_NAME_READ")
-var hostGroupName = os.Getenv("HOST_GROUP_NAME")
-var volumeID = os.Getenv("VOLUME_ID")
-var volumeName = os.Getenv("VOLUME_NAME")
-var snapshotRuleID = os.Getenv("SNAPSHOT_RULE_ID")
-var replicationRuleID = os.Getenv("REPLICATION_RULE_ID")
-var snapshotRuleName = os.Getenv("SNAPSHOT_RULE_NAME")
-var replicationRuleName = os.Getenv("REPLICATION_RULE_NAME")
-var policyName = os.Getenv("PROTECTION_POLICY_NAME")
-var policyID = os.Getenv("PROTECTION_POLICY_ID")
-var volumeGroupName = os.Getenv("VOLUME_GROUP_NAME")
-var volumeGroupSnapshotName = os.Getenv("VOLUME_GROUP_SNAPSHOT_NAME")
-var volumeGroupSnapshotID = os.Getenv("VOLUME_GROUP_SNAPSHOT_ID")
-var volumeSnapshotID = os.Getenv("VOLUME_SNAPSHOT_ID")
-var volumeSnapshotName = os.Getenv("VOLUME_SNAPSHOT_NAME")
+
+var endpoint = setDefault(os.Getenv("POWERSTORE_ENDPOINT"), "http://localhost:3003/api/rest")
+var username = setDefault(os.Getenv("POWERSTORE_USERNAME"), "test")
+var password = setDefault(os.Getenv("POWERSTORE_PASSWORD"), "test")
+var hostID = setDefault(os.Getenv("HOST_ID"), "tfacc_host_id")
+var hostIDRead = setDefault(os.Getenv("HOST_ID_READ"), "tfacc_host_id")
+var hostGroupID = setDefault(os.Getenv("HOST_GROUP_ID"), "tfacc_host_group_id")
+var volumeGroupID = setDefault(os.Getenv("VOLUME_GROUP_ID"), "tfacc_volume_group_id")
+var hostName = setDefault(os.Getenv("HOST_NAME"), "tfacc_host_name")
+var hostNameRead = setDefault(os.Getenv("HOST_NAME_READ"), "tfacc_host_name")
+var hostGroupName = setDefault(os.Getenv("HOST_GROUP_NAME"), "tfacc_host_group_name")
+var volumeID = setDefault(os.Getenv("VOLUME_ID"), "tfacc_volume_id")
+var volumeName = setDefault(os.Getenv("VOLUME_NAME"), "tfacc_volume_name")
+var snapshotRuleID = setDefault(os.Getenv("SNAPSHOT_RULE_ID"), "tfacc_snapshot_rule_id")
+var replicationRuleID = setDefault(os.Getenv("REPLICATION_RULE_ID"), "tfacc_replication_rule_id")
+var snapshotRuleName = setDefault(os.Getenv("SNAPSHOT_RULE_NAME"), "tfacc_snapshot_rule_name")
+var replicationRuleName = setDefault(os.Getenv("REPLICATION_RULE_NAME"), "tfacc_replication_rule_name")
+var policyName = setDefault(os.Getenv("PROTECTION_POLICY_NAME"), "tfacc_policy_name")
+var policyID = setDefault(os.Getenv("PROTECTION_POLICY_ID"), "tfacc_policy_id")
+var volumeGroupName = setDefault(os.Getenv("VOLUME_GROUP_NAME"), "tfacc_volume_group_name")
+var volumeGroupSnapshotName = setDefault(os.Getenv("VOLUME_GROUP_SNAPSHOT_NAME"), "tfacc_volume_group_snapshot_name")
+var volumeGroupSnapshotID = setDefault(os.Getenv("VOLUME_GROUP_SNAPSHOT_ID"), "tfacc_volume_group_snapshot_id")
+var volumeSnapshotID = setDefault(os.Getenv("VOLUME_SNAPSHOT_ID"), "tfacc_volume_snapshot_id")
+var volumeSnapshotName = setDefault(os.Getenv("VOLUME_SNAPSHOT_NAME"), "tfacc_volume_snapshot_name")
 
 var ProviderConfigForTesting = ``
 
 func init() {
-	username := os.Getenv("POWERSTORE_USERNAME")
-	password := os.Getenv("POWERSTORE_PASSWORD")
-	endpoint := os.Getenv("POWERSTORE_ENDPOINT")
+
+	username := username
+	password := password
+	endpoint := endpoint
 	insecure := "true"
 
 	ProviderConfigForTesting = fmt.Sprintf(`
@@ -78,16 +80,23 @@ func init() {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("POWERSTORE_USERNAME"); v == "" {
+	if v := username; v == "" {
 		t.Fatal("POWERSTORE_USERNAME must be set for acceptance tests")
 	}
 
-	if v := os.Getenv("POWERSTORE_PASSWORD"); v == "" {
+	if v := password; v == "" {
 		t.Fatal("POWERSTORE_PASSWORD must be set for acceptance tests")
 	}
 
-	if v := os.Getenv("POWERSTORE_ENDPOINT"); v == "" {
+	if v := endpoint; v == "" {
 		t.Fatal("POWERSTORE_ENDPOINT must be set for acceptance tests")
 	}
 
+}
+
+func setDefault(osInput string, defaultStr string) string {
+	if osInput == "" {
+		return defaultStr
+	}
+	return osInput
 }

--- a/powerstore/resource_host_group_test.go
+++ b/powerstore/resource_host_group_test.go
@@ -45,6 +45,29 @@ func TestAccHostGroup_Create(t *testing.T) {
 					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "host_ids.0", hostID),
 				),
 			},
+			// Import Testing
+			{
+				Config:       ProviderConfigForTesting + HostGroupParamsCreate,
+				ResourceName: "powerstore_hostgroup.test",
+				ImportState:  true,
+				ExpectError:  nil,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					assert.Equal(t, "test_hostgroup", s[0].Attributes["name"])
+					assert.Equal(t, "Test Create Host Group", s[0].Attributes["description"])
+					assert.Equal(t, hostID, s[0].Attributes["host_ids.0"])
+					return nil
+				},
+			},
+			// Update Testing
+			{
+				Config: ProviderConfigForTesting + HostGroupParamsUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "name", "test_hostgroup"),
+					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "description", "Test Update Host Group"),
+					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "host_ids.0", hostID),
+				),
+			},
+			// Remove host before cleanup
 			{
 				Config: ProviderConfigForTesting + HostGroupParamsUpdateRemoveHost,
 			},
@@ -162,100 +185,6 @@ func TestAccHostGroup_CreateWithHostIDAndName(t *testing.T) {
 			{
 				Config:      ProviderConfigForTesting + HostGroupParamsWithHostIDAndHostName,
 				ExpectError: regexp.MustCompile(InvalidAttributeCombinationErrorMsg),
-			},
-		},
-	})
-}
-
-// Test to Update existing HostGroup Params
-func TestAccHostGroup_Update(t *testing.T) {
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("Dont run with units tests because it will try to create the context")
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: ProviderConfigForTesting + HostGroupParamsCreate,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "name", "test_hostgroup"),
-					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "description", "Test Create Host Group"),
-					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "host_ids.0", hostID),
-				),
-			},
-			{
-				Config: ProviderConfigForTesting + HostGroupParamsUpdate,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "name", "test_hostgroup"),
-					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "description", "Test Update Host Group"),
-					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "host_ids.0", hostID),
-				),
-			},
-			{
-				Config: ProviderConfigForTesting + HostGroupParamsUpdateRemoveHost,
-			},
-		},
-	})
-}
-
-// Test to Update existing HostGroup Params
-func TestAccHostGroup_UpdateRemoveHost(t *testing.T) {
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("Dont run with units tests because it will try to create the context")
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: ProviderConfigForTesting + HostGroupParamsCreate,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "name", "test_hostgroup"),
-					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "description", "Test Create Host Group"),
-					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "host_ids.0", hostID),
-				),
-			},
-			{
-				Config: ProviderConfigForTesting + HostGroupParamsUpdateRemoveHost,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "name", "test_hostgroup"),
-					resource.TestCheckResourceAttr("powerstore_hostgroup.test", "description", "Test Create Host Group"),
-				),
-			},
-		},
-	})
-}
-
-// Test to import host group successfully
-func TestAccHostGroup_ImportSuccess(t *testing.T) {
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("Dont run with units tests because it will try to create the context")
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: ProviderConfigForTesting + HostGroupParamsCreate,
-			},
-			{
-				Config:       ProviderConfigForTesting + HostGroupParamsCreate,
-				ResourceName: "powerstore_hostgroup.test",
-				ImportState:  true,
-				ExpectError:  nil,
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					assert.Equal(t, "test_hostgroup", s[0].Attributes["name"])
-					assert.Equal(t, "Test Create Host Group", s[0].Attributes["description"])
-					assert.Equal(t, hostID, s[0].Attributes["host_ids.0"])
-					return nil
-				},
-			},
-			{
-				Config: ProviderConfigForTesting + HostGroupParamsUpdateRemoveHost,
 			},
 		},
 	})

--- a/powerstore/resource_host_test.go
+++ b/powerstore/resource_host_test.go
@@ -45,6 +45,18 @@ func TestAccHost_Create(t *testing.T) {
 					resource.TestCheckResourceAttr("powerstore_host.test", "description", "Test Host Resource"),
 				),
 			},
+			{
+				Config:            ProviderConfigForTesting + HostParamsCreate,
+				ResourceName:      "powerstore_host.test",
+				ImportState:       true,
+				ExpectError:       nil,
+				ImportStateVerify: true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					assert.Equal(t, "tf_host_acc_new", s[0].Attributes["name"])
+					assert.Equal(t, "Linux", s[0].Attributes["os_type"])
+					return nil
+				},
+			},
 		},
 	})
 }
@@ -208,37 +220,6 @@ func TestAccHost_ImportFailure(t *testing.T) {
 			},
 		},
 	})
-}
-
-// Test to import successfully
-func TestAccHost_ImportSuccess(t *testing.T) {
-
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("Dont run with units tests because it will try to create the context")
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: ProviderConfigForTesting + HostParamsCreate,
-			},
-			{
-				Config:            ProviderConfigForTesting + HostParamsCreate,
-				ResourceName:      "powerstore_host.test",
-				ImportState:       true,
-				ExpectError:       nil,
-				ImportStateVerify: true,
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					assert.Equal(t, "tf_host_acc_new", s[0].Attributes["name"])
-					assert.Equal(t, "Linux", s[0].Attributes["os_type"])
-					return nil
-				},
-			},
-		},
-	})
-
 }
 
 var HostParamsCreate = `

--- a/powerstore/resource_protection_policy_test.go
+++ b/powerstore/resource_protection_policy_test.go
@@ -46,6 +46,20 @@ func TestAccProtectionPolicy_Create(t *testing.T) {
 					resource.TestCheckResourceAttr("powerstore_protectionpolicy.test", "snapshot_rule_ids.0", snapshotRuleID),
 				),
 			},
+			{
+				Config:       ProtectionPolicyParamsCreate,
+				ResourceName: "powerstore_protectionpolicy.test",
+				ImportState:  true,
+				ExpectError:  nil,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					assert.Equal(t, "protectionpolicy_acc_new", s[0].Attributes["name"])
+					assert.Equal(t, "Test CreateProtectionPolicy", s[0].Attributes["description"])
+					assert.Equal(t, "Protection", s[0].Attributes["type"])
+					assert.Equal(t, replicationRuleID, s[0].Attributes["replication_rule_ids.0"])
+					assert.Equal(t, snapshotRuleID, s[0].Attributes["snapshot_rule_ids.0"])
+					return nil
+				},
+			},
 		},
 	})
 }
@@ -215,37 +229,6 @@ func TestAccProtectionPolicy_ImportFailure(t *testing.T) {
 				ImportState:   true,
 				ExpectError:   regexp.MustCompile(ImportPPDetailErrorMsg),
 				ImportStateId: "invalid-id",
-			},
-		},
-	})
-}
-
-// Test to import protection policy successfully
-func TestAccProtectionPolicy_ImportSuccess(t *testing.T) {
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("Dont run with units tests because it will try to create the context")
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: ProtectionPolicyParamsCreate,
-			},
-			{
-				Config:       ProtectionPolicyParamsCreate,
-				ResourceName: "powerstore_protectionpolicy.test",
-				ImportState:  true,
-				ExpectError:  nil,
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					assert.Equal(t, "protectionpolicy_acc_new", s[0].Attributes["name"])
-					assert.Equal(t, "Test CreateProtectionPolicy", s[0].Attributes["description"])
-					assert.Equal(t, "Protection", s[0].Attributes["type"])
-					assert.Equal(t, replicationRuleID, s[0].Attributes["replication_rule_ids.0"])
-					assert.Equal(t, snapshotRuleID, s[0].Attributes["snapshot_rule_ids.0"])
-					return nil
-				},
 			},
 		},
 	})

--- a/powerstore/resource_snapshot_test.go
+++ b/powerstore/resource_snapshot_test.go
@@ -45,6 +45,17 @@ func TestAccVolumeSnapshot_Create(t *testing.T) {
 					resource.TestCheckResourceAttr("powerstore_volume_snapshot.test", "description", "Test Snapshot Resource"),
 				),
 			},
+			// Import Testing
+			{
+				Config:       ProviderConfigForTesting + SnapParamsCreate,
+				ResourceName: "powerstore_volume_snapshot.test",
+				ImportState:  true,
+				ExpectError:  nil,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					assert.Equal(t, "tf_snap_acc", s[0].Attributes["name"])
+					return nil
+				},
+			},
 		},
 	})
 }
@@ -226,34 +237,6 @@ func TestAccVolumeSnapshot_ImportFailure(t *testing.T) {
 				ImportState:   true,
 				ExpectError:   regexp.MustCompile(ImportSnapshotDetailErrorMsg),
 				ImportStateId: "invalid-id",
-			},
-		},
-	})
-}
-
-// Test to import successfully
-func TestAccVolumeSnapshot_ImportSuccess(t *testing.T) {
-
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("Dont run with units tests because it will try to create the context")
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: ProviderConfigForTesting + SnapParamsCreate,
-			},
-			{
-				Config:       ProviderConfigForTesting + SnapParamsCreate,
-				ResourceName: "powerstore_volume_snapshot.test",
-				ImportState:  true,
-				ExpectError:  nil,
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					assert.Equal(t, "tf_snap_acc", s[0].Attributes["name"])
-					return nil
-				},
 			},
 		},
 	})

--- a/powerstore/resource_storagecontainer.go
+++ b/powerstore/resource_storagecontainer.go
@@ -20,10 +20,11 @@ package powerstore
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"log"
 	client "terraform-provider-powerstore/client"
 	"terraform-provider-powerstore/models"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
 
 	"github.com/dell/gopowerstore"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -154,7 +155,7 @@ func (r *resourceStorageContainer) Create(ctx context.Context, req resource.Crea
 	if err1 != nil {
 		resp.Diagnostics.AddError(
 			"Error getting Storage Container after creation",
-			"Could not get Storage Container, unexpected error: "+err.Error(),
+			"Could not get Storage Container, unexpected error: "+err1.Error(),
 		)
 		return
 	}

--- a/powerstore/resource_storagecontainer_test.go
+++ b/powerstore/resource_storagecontainer_test.go
@@ -46,6 +46,20 @@ func TestAccStorageContainer_Create(t *testing.T) {
 					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "high_water_mark", "70"),
 				),
 			},
+			// Import test
+			{
+				Config:            StorageContainerParamsCreate,
+				ResourceName:      "powerstore_storagecontainer.test",
+				ImportState:       true,
+				ExpectError:       nil,
+				ImportStateVerify: true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					assert.Equal(t, "scterraform_acc", s[0].Attributes["name"])
+					assert.Equal(t, "10737418240", s[0].Attributes["quota"])
+					assert.Equal(t, "SCSI", s[0].Attributes["storage_protocol"])
+					return nil
+				},
+			},
 		},
 	})
 }
@@ -78,6 +92,11 @@ func TestAccStorageContainer_Update(t *testing.T) {
 					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "high_water_mark", "60"),
 				),
 			},
+			// Test to update existing StorageContainer params but will result in error
+			{
+				Config:      StorageContainerParamsCreateServerError,
+				ExpectError: regexp.MustCompile(UpdateSCDetailErrorMsg),
+			},
 		},
 	})
 }
@@ -108,33 +127,6 @@ func TestAccStorageContainer_CreateWithInvalidValues(t *testing.T) {
 	}
 }
 
-// Test to update existing StorageContainer params but will result in error
-func TestAccStorageContainer_UpdateError(t *testing.T) {
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("Dont run with units tests because it will try to create the context")
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: StorageContainerParamsCreate,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "name", "scterraform_acc"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "quota", "10737418240"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "storage_protocol", "SCSI"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "high_water_mark", "70"),
-				),
-			},
-			{
-				Config:      StorageContainerParamsCreateServerError,
-				ExpectError: regexp.MustCompile(UpdateSCDetailErrorMsg),
-			},
-		},
-	})
-}
-
 // Test to import resource but resulting in error
 func TestAccStorageContainer_ImportFailure(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
@@ -154,44 +146,6 @@ func TestAccStorageContainer_ImportFailure(t *testing.T) {
 			},
 		},
 	})
-}
-
-// Test to import successfully
-func TestAccStorageContainer_ImportSuccess(t *testing.T) {
-
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("Dont run with units tests because it will try to create the context")
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: StorageContainerParamsCreate,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "name", "scterraform_acc"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "quota", "10737418240"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "storage_protocol", "SCSI"),
-					resource.TestCheckResourceAttr("powerstore_storagecontainer.test", "high_water_mark", "70"),
-				),
-			},
-			{
-				Config:            StorageContainerParamsCreate,
-				ResourceName:      "powerstore_storagecontainer.test",
-				ImportState:       true,
-				ExpectError:       nil,
-				ImportStateVerify: true,
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					assert.Equal(t, "scterraform_acc", s[0].Attributes["name"])
-					assert.Equal(t, "10737418240", s[0].Attributes["quota"])
-					assert.Equal(t, "SCSI", s[0].Attributes["storage_protocol"])
-					return nil
-				},
-			},
-		},
-	})
-
 }
 
 var StorageContainerParamsCreate = `

--- a/powerstore/resource_volume.go
+++ b/powerstore/resource_volume.go
@@ -439,7 +439,7 @@ func (r volumeResource) Create(ctx context.Context, req resource.CreateRequest, 
 	volGroupMapping, err := r.client.PStoreClient.GetVolumeGroupsByVolumeID(context.Background(), volCreateResponse.ID)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error fetching volume host mapping",
+			"Error fetching volume group mapping",
 			"Could not create volume, unexpected error: "+err.Error(),
 		)
 		return
@@ -569,7 +569,7 @@ func (r volumeResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	// Get Host Mapping from volume ID
-	hostMapping, err := r.client.PStoreClient.GetHostVolumeMappingByVolumeID(context.Background(), volID)
+	hostMapping, err := r.client.PStoreClient.GetHostVolumeMappingByVolumeID(context.Background(), volResponse.ID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error fetching volume host mapping",
@@ -579,7 +579,7 @@ func (r volumeResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	// Get Volume Group Mapping details from API
-	volGroupMapping, err := r.client.PStoreClient.GetVolumeGroupsByVolumeID(context.Background(), volID)
+	volGroupMapping, err := r.client.PStoreClient.GetVolumeGroupsByVolumeID(context.Background(), volResponse.ID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error fetching volume host mapping",

--- a/powerstore/resource_volume_group_snapshot_test.go
+++ b/powerstore/resource_volume_group_snapshot_test.go
@@ -18,11 +18,12 @@ limitations under the License.
 package powerstore
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -43,6 +44,18 @@ func TestAccVolumeGroupSnapshot_Create(t *testing.T) {
 					resource.TestCheckResourceAttr("powerstore_volumegroup_snapshot.test", "name", "test_snap"),
 					resource.TestCheckResourceAttr("powerstore_volumegroup_snapshot.test", "description", "Test Snapshot Resource"),
 				),
+			},
+			// Import Test
+			{
+				Config:            ProviderConfigForTesting + VolumeGroupSnapParamsCreate,
+				ResourceName:      "powerstore_volumegroup_snapshot.test",
+				ImportState:       true,
+				ExpectError:       nil,
+				ImportStateVerify: true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					assert.Equal(t, "test_snap", s[0].Attributes["name"])
+					return nil
+				},
 			},
 		},
 	})
@@ -218,35 +231,6 @@ func TestAccVolumeGroupSnapshot_ImportFailure(t *testing.T) {
 				ImportState:   true,
 				ExpectError:   regexp.MustCompile(ImportSnapshotDetailErrorMsg),
 				ImportStateId: "invalid-id",
-			},
-		},
-	})
-}
-
-// Test to import successfully
-func TestAccVolumeGroupSnapshot_ImportSuccess(t *testing.T) {
-
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("Dont run with units tests because it will try to create the context")
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: ProviderConfigForTesting + VolumeGroupSnapParamsCreate,
-			},
-			{
-				Config:            ProviderConfigForTesting + VolumeGroupSnapParamsCreate,
-				ResourceName:      "powerstore_volumegroup_snapshot.test",
-				ImportState:       true,
-				ExpectError:       nil,
-				ImportStateVerify: true,
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					assert.Equal(t, "test_snap", s[0].Attributes["name"])
-					return nil
-				},
 			},
 		},
 	})

--- a/powerstore/resource_volume_group_test.go
+++ b/powerstore/resource_volume_group_test.go
@@ -45,6 +45,19 @@ func TestAccVolumeGroup_Create(t *testing.T) {
 					resource.TestCheckResourceAttr("powerstore_volumegroup.test", "is_write_order_consistent", "false"),
 				),
 			},
+			// Import test
+			{
+				Config:       ProviderConfigForTesting + VolumeGroupParamsCreate,
+				ResourceName: "powerstore_volumegroup.test",
+				ImportState:  true,
+				ExpectError:  nil,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					assert.Equal(t, "tf_volume_group_new", s[0].Attributes["name"])
+					assert.Equal(t, "Creating Volume Group", s[0].Attributes["description"])
+					assert.Equal(t, "false", s[0].Attributes["is_write_order_consistent"])
+					return nil
+				},
+			},
 		},
 	})
 }
@@ -404,35 +417,6 @@ func TestAccVolumeGroup_UpdateRemoveVolume(t *testing.T) {
 					resource.TestCheckResourceAttr("powerstore_volumegroup.test", "description", "Updating Volume Group"),
 					resource.TestCheckResourceAttr("powerstore_volumegroup.test", "is_write_order_consistent", "false"),
 				),
-			},
-		},
-	})
-}
-
-// Test to import volume group successfully
-func TestAccVolumeGroup_ImportSuccess(t *testing.T) {
-	if os.Getenv("TF_ACC") == "" {
-		t.Skip("Dont run with units tests because it will try to create the context")
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testProviderFactory,
-		Steps: []resource.TestStep{
-			{
-				Config: ProviderConfigForTesting + VolumeGroupParamsCreate,
-			},
-			{
-				Config:       ProviderConfigForTesting + VolumeGroupParamsCreate,
-				ResourceName: "powerstore_volumegroup.test",
-				ImportState:  true,
-				ExpectError:  nil,
-				ImportStateCheck: func(s []*terraform.InstanceState) error {
-					assert.Equal(t, "tf_volume_group_new", s[0].Attributes["name"])
-					assert.Equal(t, "Creating Volume Group", s[0].Attributes["description"])
-					assert.Equal(t, "false", s[0].Attributes["is_write_order_consistent"])
-					return nil
-				},
 			},
 		},
 	})


### PR DESCRIPTION
# Description
- Set some default values and clean up some of the tests to work with the unit test mock server.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests


```
TF_ACC=1 go test -v -timeout 1h
=== RUN   TestAccHostGroupDs_FetchHostGroup
--- PASS: TestAccHostGroupDs_FetchHostGroup (29.34s)
=== RUN   TestAccHostDs_FetchHost
--- PASS: TestAccHostDs_FetchHost (24.33s)
=== RUN   TestAccHostDs_FetchHostNegative
--- PASS: TestAccHostDs_FetchHostNegative (4.48s)
=== RUN   TestAccProtectionPolicyDs_FetchPolicy
--- PASS: TestAccProtectionPolicyDs_FetchPolicy (24.85s)
=== RUN   TestAccProtectionPolicyDs_FetchPolicyNegative
--- PASS: TestAccProtectionPolicyDs_FetchPolicyNegative (4.48s)
=== RUN   TestAccSnapshotRuleDs_FetchSnapshotRule
--- PASS: TestAccSnapshotRuleDs_FetchSnapshotRule (27.56s)
=== RUN   TestAccVolumeGroupSnapshotDs_FetchVolumeGroupSnapshot
--- PASS: TestAccVolumeGroupSnapshotDs_FetchVolumeGroupSnapshot (28.11s)
=== RUN   TestAccVolumeGroupDs_FetchVolumeGroup
--- PASS: TestAccVolumeGroupDs_FetchVolumeGroup (28.22s)
=== RUN   TestAccVolumeDs_FetchVolumeSnapshot
--- PASS: TestAccVolumeDs_FetchVolumeSnapshot (29.51s)
=== RUN   TestAccVolumeDs_FetchVolume
--- PASS: TestAccVolumeDs_FetchVolume (25.92s)
=== RUN   TestAccHostGroup_Create
--- PASS: TestAccHostGroup_Create (25.48s)
=== RUN   TestAccHostGroup_CreateWithInvalidValues
--- PASS: TestAccHostGroup_CreateWithInvalidValues (4.07s)
=== RUN   TestAccHostGroup_CreateWithInvalidHostID
--- PASS: TestAccHostGroup_CreateWithInvalidHostID (4.00s)
=== RUN   TestAccHostGroup_CreateWithBlankName
--- PASS: TestAccHostGroup_CreateWithBlankName (1.80s)
=== RUN   TestAccHostGroup_CreateWithHostName
--- PASS: TestAccHostGroup_CreateWithHostName (15.64s)
=== RUN   TestAccHostGroup_CreateWithInvalidHostName
--- PASS: TestAccHostGroup_CreateWithInvalidHostName (4.04s)
=== RUN   TestAccHostGroup_CreateWithHostIDAndName
--- PASS: TestAccHostGroup_CreateWithHostIDAndName (1.66s)
=== RUN   TestAccHostGroup_ImportFailure
--- PASS: TestAccHostGroup_ImportFailure (2.82s)
=== RUN   TestAccHost_Create
--- PASS: TestAccHost_Create (10.89s)
=== RUN   TestAccHost_CreateSingleCHAP
--- PASS: TestAccHost_CreateSingleCHAP (9.04s)
=== RUN   TestAccHost_CreateWithoutPolicy
--- PASS: TestAccHost_CreateWithoutPolicy (1.74s)
=== RUN   TestAccHost_CreateWithoutName
--- PASS: TestAccHost_CreateWithoutName (1.59s)
=== RUN   TestAccHost_Rename
--- PASS: TestAccHost_Rename (15.75s)
=== RUN   TestAccHost_AddRemoveInitiators
--- PASS: TestAccHost_AddRemoveInitiators (22.98s)
=== RUN   TestAccHost_ModifyInitiators
--- PASS: TestAccHost_ModifyInitiators (16.68s)
=== RUN   TestAccHost_ImportFailure
--- PASS: TestAccHost_ImportFailure (2.77s)
=== RUN   TestAccProtectionPolicy_Create
--- PASS: TestAccProtectionPolicy_Create (11.07s)
=== RUN   TestAccProtectionPolicy_Update
--- PASS: TestAccProtectionPolicy_Update (15.65s)
=== RUN   TestAccProtectionPolicy_CreateWithInvalidValues
--- PASS: TestAccProtectionPolicy_CreateWithInvalidValues (4.05s)
=== RUN   TestAccProtectionPolicy_UpdateError
--- PASS: TestAccProtectionPolicy_UpdateError (12.26s)
=== RUN   TestAccProtectionPolicy_CreateWithMutuallyExclusiveParams
--- PASS: TestAccProtectionPolicy_CreateWithMutuallyExclusiveParams (3.14s)
=== RUN   TestAccProtectionPolicy_CreateWithSnapshotRuleName
--- PASS: TestAccProtectionPolicy_CreateWithSnapshotRuleName (8.63s)
=== RUN   TestAccProtectionPolicy_CreateWithReplicationRuleName
--- PASS: TestAccProtectionPolicy_CreateWithReplicationRuleName (9.02s)
=== RUN   TestAccProtectionPolicy_ImportFailure
--- PASS: TestAccProtectionPolicy_ImportFailure (2.82s)
=== RUN   TestAccVolumeSnapshot_Create
--- PASS: TestAccVolumeSnapshot_Create (10.95s)
=== RUN   TestAccVolumeSnapshot_InvalidSnapshotVolumeID
--- PASS: TestAccVolumeSnapshot_InvalidSnapshotVolumeID (4.00s)
=== RUN   TestAccVolumeSnapshot_UpdateSnapshotRename
--- PASS: TestAccVolumeSnapshot_UpdateSnapshotRename (15.62s)
=== RUN   TestAccVolumeSnapshot_UpdateSnapshotVolumeName
--- PASS: TestAccVolumeSnapshot_UpdateSnapshotVolumeName (11.71s)
=== RUN   TestAccVolumeSnapshot_CreateWithoutName
--- PASS: TestAccVolumeSnapshot_CreateWithoutName (9.42s)
=== RUN   TestAccVolumeSnapshot_CreateWithoutExpiration
--- PASS: TestAccVolumeSnapshot_CreateWithoutExpiration (8.52s)
=== RUN   TestAccVolumeSnapshot_CreateWithoutVolume
--- PASS: TestAccVolumeSnapshot_CreateWithoutVolume (1.61s)
=== RUN   TestAccVolumeSnapshot_CreateWithVolumeName
--- PASS: TestAccVolumeSnapshot_CreateWithVolumeName (8.64s)
=== RUN   TestAccVolumeSnapshot_CreateWithInvalidVolumeName
--- PASS: TestAccVolumeSnapshot_CreateWithInvalidVolumeName (4.13s)
=== RUN   TestAccVolumeSnapshot_ImportFailure
--- PASS: TestAccVolumeSnapshot_ImportFailure (2.74s)
=== RUN   TestAccSnapshotRule_CreateSnapShotRule
--- PASS: TestAccSnapshotRule_CreateSnapShotRule (17.38s)
=== RUN   TestAccSnapshotRule_UpdateSnapShotRule
--- PASS: TestAccSnapshotRule_UpdateSnapShotRule (16.14s)
=== RUN   TestAccSnapshotRule_CreateSnapShotRuleWithInvalidValues
--- PASS: TestAccSnapshotRule_CreateSnapShotRuleWithInvalidValues (6.48s)
=== RUN   TestAccSnapshotRule_ImportFailure
--- PASS: TestAccSnapshotRule_ImportFailure (2.76s)
=== RUN   TestAccSnapshotRule_ImportSuccess
--- PASS: TestAccSnapshotRule_ImportSuccess (10.88s)
=== RUN   TestAccStorageContainer_Create
--- PASS: TestAccStorageContainer_Create (11.13s)
=== RUN   TestAccStorageContainer_Update
--- PASS: TestAccStorageContainer_Update (19.17s)
=== RUN   TestAccStorageContainer_CreateWithInvalidValues
--- PASS: TestAccStorageContainer_CreateWithInvalidValues (6.49s)
=== RUN   TestAccStorageContainer_ImportFailure
--- PASS: TestAccStorageContainer_ImportFailure (2.97s)
=== RUN   TestAccVolumeGroupSnapshot_Create
--- PASS: TestAccVolumeGroupSnapshot_Create (11.01s)
=== RUN   TestAccVolumeGroupSnapshot_InvalidSnapshotVolumegroupID
--- PASS: TestAccVolumeGroupSnapshot_InvalidSnapshotVolumegroupID (4.11s)
=== RUN   TestAccVolumeGroupSnapshot_UpdateSnapshotRename
--- PASS: TestAccVolumeGroupSnapshot_UpdateSnapshotRename (15.96s)
=== RUN   TestAccVolumeGroupSnapshot_UpdateSnapshotVolumeName
--- PASS: TestAccVolumeGroupSnapshot_UpdateSnapshotVolumeName (11.71s)
=== RUN   TestAccVolumeGroupSnapshot_CreateWithoutName
--- PASS: TestAccVolumeGroupSnapshot_CreateWithoutName (1.62s)
=== RUN   TestAccVolumeGroupSnapshot_CreateWithoutExpiration
--- PASS: TestAccVolumeGroupSnapshot_CreateWithoutExpiration (8.78s)
=== RUN   TestAccVolumeGroupSnapshot_CreateWithoutVolume
--- PASS: TestAccVolumeGroupSnapshot_CreateWithoutVolume (1.66s)
=== RUN   TestAccVolumeGroupSnapshot_CreateWithVolumeGroupName
--- PASS: TestAccVolumeGroupSnapshot_CreateWithVolumeGroupName (9.20s)
=== RUN   TestAccVolumeGroupSnapshot_CreateWithInvalidVolumeGroupName
--- PASS: TestAccVolumeGroupSnapshot_CreateWithInvalidVolumeGroupName (4.09s)
=== RUN   TestAccVolumeGroupSnapshot_ImportFailure
--- PASS: TestAccVolumeGroupSnapshot_ImportFailure (2.88s)
=== RUN   TestAccVolumeGroup_Create
--- PASS: TestAccVolumeGroup_Create (11.08s)
=== RUN   TestAccVolumeGroup_CreateWithoutName
--- PASS: TestAccVolumeGroup_CreateWithoutName (1.73s)
=== RUN   TestAccVolumeGroup_CreateWithInvalidPolicy
--- PASS: TestAccVolumeGroup_CreateWithInvalidPolicy (4.30s)
=== RUN   TestAccVolumeGroup_CreateWithInvalidVolume
--- PASS: TestAccVolumeGroup_CreateWithInvalidVolume (4.43s)
=== RUN   TestAccVolumeGroup_Update
--- PASS: TestAccVolumeGroup_Update (16.59s)
=== RUN   TestAccVolumeGroup_UpdateError
--- PASS: TestAccVolumeGroup_UpdateError (13.53s)
=== RUN   TestAccVolumeGroup_CreateWithVolumeName
--- PASS: TestAccVolumeGroup_CreateWithVolumeName (8.77s)
=== RUN   TestAccVolumeGroup_CreateWithPolicyName
--- PASS: TestAccVolumeGroup_CreateWithPolicyName (8.74s)
=== RUN   TestAccVolumeGroup_CreateWithInvalidPolicyName
--- PASS: TestAccVolumeGroup_CreateWithInvalidPolicyName (4.15s)
=== RUN   TestAccVolumeGroup_CreateWithVolumeIDAndName
--- PASS: TestAccVolumeGroup_CreateWithVolumeIDAndName (1.63s)
=== RUN   TestAccVolumeGroup_CreateWithPolicyIDAndName
--- PASS: TestAccVolumeGroup_CreateWithPolicyIDAndName (1.66s)
=== RUN   TestAccVolumeGroup_UpdateAddPolicy
--- PASS: TestAccVolumeGroup_UpdateAddPolicy (15.86s)
=== RUN   TestAccVolumeGroup_UpdateAddVolume
--- PASS: TestAccVolumeGroup_UpdateAddVolume (16.60s)
=== RUN   TestAccVolumeGroup_UpdateAddPolicyNegative
--- PASS: TestAccVolumeGroup_UpdateAddPolicyNegative (12.49s)
=== RUN   TestAccVolumeGroup_UpdateRemovePolicy
--- PASS: TestAccVolumeGroup_UpdateRemovePolicy (15.29s)
=== RUN   TestAccVolumeGroup_UpdateRemoveVolume
--- PASS: TestAccVolumeGroup_UpdateRemoveVolume (15.35s)
=== RUN   TestAccVolumeGroup_ImportFailure
--- PASS: TestAccVolumeGroup_ImportFailure (2.79s)
=== RUN   TestAccVolume_CreateVolume
--- PASS: TestAccVolume_CreateVolume (12.25s)
=== RUN   TestAccVolume_UpdateVolumeRename
--- PASS: TestAccVolume_UpdateVolumeRename (16.33s)
=== RUN   TestAccVolume_CreateVolumeWithMBInInt
--- PASS: TestAccVolume_CreateVolumeWithMBInInt (8.73s)
=== RUN   TestAccVolume_CreateVolumeWithTBInFloat
--- PASS: TestAccVolume_CreateVolumeWithTBInFloat (9.09s)
=== RUN   TestAccVolume_CreateVolumeWithPB
--- PASS: TestAccVolume_CreateVolumeWithPB (1.61s)
=== RUN   TestAccVolume_CreateVolumeWithInvalidCapUnit
--- PASS: TestAccVolume_CreateVolumeWithInvalidCapUnit (1.60s)
=== RUN   TestAccVolume_UpdateVolumeGb
--- PASS: TestAccVolume_UpdateVolumeGb (16.20s)
=== RUN   TestAccVolume_UpdateVolumeGbError1
--- PASS: TestAccVolume_UpdateVolumeGbError1 (13.19s)
=== RUN   TestAccVolume_UpdateVolumeSizeGbToTb
--- PASS: TestAccVolume_UpdateVolumeSizeGbToTb (16.26s)
=== RUN   TestAccVolume_UpdateVolumeApplianceID
--- PASS: TestAccVolume_UpdateVolumeApplianceID (8.95s)
=== RUN   TestAccVolume_UpdateVolumeInvalidApplianceID
--- PASS: TestAccVolume_UpdateVolumeInvalidApplianceID (4.12s)
=== RUN   TestAccVolume_UpdateVolumePerformancePolicyID
--- PASS: TestAccVolume_UpdateVolumePerformancePolicyID (1.60s)
=== RUN   TestAccVolume_AddVolumeGroupID
--- PASS: TestAccVolume_AddVolumeGroupID (9.09s)
=== RUN   TestAccVolume_UpdateVolumeGroupID
--- PASS: TestAccVolume_UpdateVolumeGroupID (24.04s)
=== RUN   TestAccVolume_AddHostID
--- PASS: TestAccVolume_AddHostID (8.85s)
=== RUN   TestAccVolume_UpdateHostID
--- PASS: TestAccVolume_UpdateHostID (24.21s)
=== RUN   TestAccVolume_UpdateHostGroupID
--- PASS: TestAccVolume_UpdateHostGroupID (18.21s)
=== RUN   TestAccVolume_UpdateHostAndHostGroupID
--- PASS: TestAccVolume_UpdateHostAndHostGroupID (12.28s)
=== RUN   TestAccVolume_AddHostGroupID
--- PASS: TestAccVolume_AddHostGroupID (8.92s)
=== RUN   TestAccVolume_AddHostAndHostGroupID
--- PASS: TestAccVolume_AddHostAndHostGroupID (3.70s)
=== RUN   TestAccVolume_ImportFailure
--- PASS: TestAccVolume_ImportFailure (2.82s)
PASS
ok      terraform-provider-powerstore/powerstore
```