### PR TITLE
Volume Group Snapshot Fix

### DIFF
--- a/models/volumegroup.go
+++ b/models/volumegroup.go
@@ -32,3 +32,11 @@ type Volumegroup struct {
 	VolumeNames            types.Set    `tfsdk:"volume_names"`
 	ProtectionPolicyName   types.String `tfsdk:"protection_policy_name"`
 }
+
+// VolumeGroupModifyLocal - VolumeGroupModifyLocal properties needed since gopowermax causes issue with setting Protection policy on patch for VolumeGroupSnapshots
+type VolumeGroupModifyLocal struct {
+	Description            string  `json:"description"`
+	Name                   string  `json:"name,omitempty"`
+	IsWriteOrderConsistent bool    `json:"is_write_order_consistent,omitempty"`
+	ExpirationTimestamp    *string `json:"expiration_timestamp,omitempty"`
+}

--- a/powerstore/resource_volume_group_snapshot.go
+++ b/powerstore/resource_volume_group_snapshot.go
@@ -284,7 +284,7 @@ func (r *resourceVGSnapshot) Update(ctx context.Context, req resource.UpdateRequ
 	volumeGroupSnapshotID := state.ID.ValueString()
 
 	//Update volume group snapshot by calling API
-	_, err := r.client.PStoreClient.ModifyVolumeGroup(context.Background(), volModify, volumeGroupSnapshotID)
+	_, err := r.client.PStoreClient.ModifyVolumeGroupSnapshot(context.Background(), volModify, volumeGroupSnapshotID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating volume group snapshot resource",
@@ -367,12 +367,12 @@ func (r resourceVGSnapshot) updateVGSnapshotState(plan, state *models.VolumeGrou
 	}
 }
 
-func (r resourceVGSnapshot) planToServer(plan models.VolumeGroupSnapshot) *gopowerstore.VolumeGroupModify {
+func (r resourceVGSnapshot) planToServer(plan models.VolumeGroupSnapshot) *models.VolumeGroupModifyLocal {
 	name := plan.Name.ValueString()
 	description := plan.Description.ValueString()
 	expirationTimeStamp := plan.ExpirationTimestamp.ValueString()
 
-	volGroupSnapshotUpdate := &gopowerstore.VolumeGroupModify{
+	volGroupSnapshotUpdate := &models.VolumeGroupModifyLocal{
 		Description:         description,
 		Name:                name,
 		ExpirationTimestamp: &expirationTimeStamp,


### PR DESCRIPTION
# Description
- After updating to the latest version of gopowerstore, it caused an error sending the protectionpolicyid for powerstore patch of VolumeGroupSnapshots since that is an invalid property.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Acceptance tests
- [x] Functional tests