### PR TITLE
Gosec 2.22 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ check:
 	go vet
 
 gosec:
-	gosec -quiet -log gosec.log -out=gosecresults.csv -fmt=csv ./...
+	gosec -quiet ./...
 
 testacc:
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m   

--- a/docs/resources/storagecontainer.md
+++ b/docs/resources/storagecontainer.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2024-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 # 
 # Licensed under the Mozilla Public License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -72,9 +72,9 @@ After the execution of above resource block, storage container container would h
 
 ### Optional
 
-- `high_water_mark` (Number) The percentage of the quota that can be consumed before an alert is raised
+- `high_water_mark` (Number) The percentage of the quota that can be consumed before an alert is raised. Allowed values are between `50` and `100` (inclusive).
 - `quota` (Number) The total number of bytes that can be provisioned/reserved against this storage container. A value of 0 means there is no limit.
-- `storage_protocol` (String) The storage protocol of Storage Container. eg: SCSI, NVMe
+- `storage_protocol` (String) The storage protocol of Storage Container. Accepted values are `SCSI` and `NVMe`.
 
 ### Read-Only
 

--- a/models/snapshotrule.go
+++ b/models/snapshotrule.go
@@ -27,7 +27,7 @@ type SnapshotRule struct {
 	TimeOfDay        types.String `tfsdk:"time_of_day"`
 	TimeZone         types.String `tfsdk:"timezone"`
 	DaysOfWeek       types.List   `tfsdk:"days_of_week"`
-	DesiredRetention types.Int64  `tfsdk:"desired_retention"`
+	DesiredRetention types.Int32  `tfsdk:"desired_retention"`
 	IsReplica        types.Bool   `tfsdk:"is_replica"`
 	NASAccessType    types.String `tfsdk:"nas_access_type"`
 	IsReadOnly       types.Bool   `tfsdk:"is_read_only"`

--- a/powerstore/resource_snapshotrule.go
+++ b/powerstore/resource_snapshotrule.go
@@ -266,7 +266,7 @@ func (r *resourceSnapshotRule) Schema(ctx context.Context, req resource.SchemaRe
 				},
 			},
 
-			"desired_retention": schema.Int64Attribute{
+			"desired_retention": schema.Int32Attribute{
 				Required:            true,
 				Description:         "The Desired snapshot retention period in hours to retain snapshots for this time period.",
 				MarkdownDescription: "The Desired snapshot retention period in hours to retain snapshots for this time period.",
@@ -591,7 +591,7 @@ func (r resourceSnapshotRule) serverToState(plan, state *models.SnapshotRule, re
 
 	state.DaysOfWeek, _ = types.ListValue(types.StringType, attributeList)
 
-	state.DesiredRetention = types.Int64Value(int64(response.DesiredRetention))
+	state.DesiredRetention = types.Int32Value(response.DesiredRetention)
 	state.IsReplica = types.BoolValue(response.IsReplica)
 	state.ManagedBy = types.StringValue(string(response.ManagedBy))
 	state.ManagedByID = types.StringValue(string(response.ManagedByID))
@@ -613,7 +613,7 @@ func (r resourceSnapshotRule) planToServer(plan models.SnapshotRule) *gopowersto
 		Interval:         gopowerstore.SnapshotRuleIntervalEnum(plan.Interval.ValueString()),
 		TimeOfDay:        plan.TimeOfDay.ValueString(),
 		TimeZone:         gopowerstore.TimeZoneEnum(plan.TimeZone.ValueString()),
-		DesiredRetention: int32(plan.DesiredRetention.ValueInt64()),
+		DesiredRetention: plan.DesiredRetention.ValueInt32(),
 		NASAccessType:    gopowerstore.NASAccessTypeEnum(plan.NASAccessType.ValueString()),
 	}
 

--- a/powerstore/resource_storagecontainer.go
+++ b/powerstore/resource_storagecontainer.go
@@ -83,8 +83,8 @@ func (r *resourceStorageContainer) Schema(ctx context.Context, req resource.Sche
 			"storage_protocol": schema.StringAttribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "The storage protocol of Storage Container.",
-				MarkdownDescription: "The storage protocol of Storage Container. eg: SCSI, NVMe",
+				Description:         "The storage protocol of Storage Container. Accepted values are 'SCSI' and 'NVMe'.",
+				MarkdownDescription: "The storage protocol of Storage Container. Accepted values are `SCSI` and `NVMe`.",
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{
 						string(gopowerstore.StorageContainerStorageProtocolEnumNVME),
@@ -96,10 +96,10 @@ func (r *resourceStorageContainer) Schema(ctx context.Context, req resource.Sche
 			"high_water_mark": schema.Int64Attribute{
 				Optional:            true,
 				Computed:            true,
-				Description:         "The percentage of the quota that can be consumed before an alert is raised.",
-				MarkdownDescription: "The percentage of the quota that can be consumed before an alert is raised",
+				Description:         "The percentage of the quota that can be consumed before an alert is raised. Allowed values are between '50' and '100' (inclusive).",
+				MarkdownDescription: "The percentage of the quota that can be consumed before an alert is raised. Allowed values are between `50` and `100` (inclusive).",
 				Validators: []validator.Int64{
-					int64validator.Between(0, 100),
+					int64validator.Between(50, 100),
 				},
 			},
 		},
@@ -337,5 +337,5 @@ func (r resourceStorageContainer) planToServer(plan, state models.StorageContain
 }
 
 func (r resourceStorageContainer) getTruncatedWatermark(plan models.StorageContainer) int16 {
-	return int16(plan.HighWaterMark.ValueInt64()) // #nosec G115 --- validated to be between 0 and 100
+	return int16(plan.HighWaterMark.ValueInt64()) // #nosec G115 --- validated to be between 50 and 100
 }

--- a/templates/resources/storagecontainer.md.tmpl
+++ b/templates/resources/storagecontainer.md.tmpl
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2024-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 # 
 # Licensed under the Mozilla Public License Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Some issues related to `Integer Overflow during Conversion` were identified by the latest release of Gosec. This is a fix for that.

Also, changed the `gosec` target in Makefile slightly so that we get the results on the console itself. I don't see any reason to log results to a CSV file.