### PR TITLE
Add error for key-only filter expression + Fix Host Resource validator to allow unknowns

### DIFF
--- a/powerstore/datasource_nfs_export_test.go
+++ b/powerstore/datasource_nfs_export_test.go
@@ -44,6 +44,15 @@ func TestAccNFSExportDs(t *testing.T) {
 				`,
 				ExpectError: regexp.MustCompile(".*Invalid PowerStore filter expression.*"),
 			},
+			// validate nfs export with invalid url query expression (empty value)
+			{
+				Config: ProviderConfigForTesting + `
+				data "powerstore_nfs_export" "test" {
+					filter_expression = "invalid"
+				}
+				`,
+				ExpectError: regexp.MustCompile(".*Invalid PowerStore filter value for query parameter.*"),
+			},
 			// validate nfs export with empty filter
 			{
 				Config: ProviderConfigForTesting + `

--- a/powerstore/helper/tfvalues.go
+++ b/powerstore/helper/tfvalues.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Mozilla Public License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://mozilla.org/MPL/2.0/
+
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import "github.com/hashicorp/terraform-plugin-framework/attr"
+
+// IsKnownValue returns true if the value is known and is not a null
+// usefull to check in planmodifiers/validators if a value has been configured
+func IsKnownValue(value attr.Value) bool {
+	return !value.IsUnknown() && !value.IsNull()
+}

--- a/powerstore/resource_host.go
+++ b/powerstore/resource_host.go
@@ -114,7 +114,7 @@ func (r *resourceHost) Schema(ctx context.Context, req resource.SchemaRequest, r
 							Description:         "Password for CHAP authentication. This value must be 12 to 64 UTF-8 characters. This password cannot be queried. CHAP password is required when the cluster CHAP mode is mutual authentication.",
 							MarkdownDescription: "Password for CHAP authentication. This value must be 12 to 64 UTF-8 characters. This password cannot be queried. CHAP password is required when the cluster CHAP mode is mutual authentication.",
 							Optional:            true,
-							// Sensitive:           true,
+							Sensitive:           true,
 						},
 						"chap_mutual_username": schema.StringAttribute{
 							Description:         "Username for CHAP authentication. This value must be 1 to 64 UTF-8 characters. CHAP username is required when the cluster CHAP mode is mutual authentication.",
@@ -130,7 +130,7 @@ func (r *resourceHost) Schema(ctx context.Context, req resource.SchemaRequest, r
 							Description:         "Password for CHAP authentication. This value must be 12 to 64 UTF-8 characters. This password cannot be queried. CHAP password is required when the cluster CHAP mode is single authentication.",
 							MarkdownDescription: "Password for CHAP authentication. This value must be 12 to 64 UTF-8 characters. This password cannot be queried. CHAP password is required when the cluster CHAP mode is single authentication.",
 							Optional:            true,
-							// Sensitive:           true,
+							Sensitive:           true,
 						},
 					},
 				},

--- a/powerstore/resource_host.go
+++ b/powerstore/resource_host.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) 2024-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Mozilla Public License Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"terraform-provider-powerstore/client"
 	"terraform-provider-powerstore/models"
+	"terraform-provider-powerstore/powerstore/helper"
 
 	"github.com/dell/gopowerstore"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -113,7 +114,7 @@ func (r *resourceHost) Schema(ctx context.Context, req resource.SchemaRequest, r
 							Description:         "Password for CHAP authentication. This value must be 12 to 64 UTF-8 characters. This password cannot be queried. CHAP password is required when the cluster CHAP mode is mutual authentication.",
 							MarkdownDescription: "Password for CHAP authentication. This value must be 12 to 64 UTF-8 characters. This password cannot be queried. CHAP password is required when the cluster CHAP mode is mutual authentication.",
 							Optional:            true,
-							Sensitive:           true,
+							// Sensitive:           true,
 						},
 						"chap_mutual_username": schema.StringAttribute{
 							Description:         "Username for CHAP authentication. This value must be 1 to 64 UTF-8 characters. CHAP username is required when the cluster CHAP mode is mutual authentication.",
@@ -129,7 +130,7 @@ func (r *resourceHost) Schema(ctx context.Context, req resource.SchemaRequest, r
 							Description:         "Password for CHAP authentication. This value must be 12 to 64 UTF-8 characters. This password cannot be queried. CHAP password is required when the cluster CHAP mode is single authentication.",
 							MarkdownDescription: "Password for CHAP authentication. This value must be 12 to 64 UTF-8 characters. This password cannot be queried. CHAP password is required when the cluster CHAP mode is single authentication.",
 							Optional:            true,
-							Sensitive:           true,
+							// Sensitive:           true,
 						},
 					},
 				},
@@ -595,28 +596,36 @@ func (r *resourceHost) ValidateConfig(ctx context.Context, req resource.Validate
 	var data models.Host
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	for _, initiator := range data.Initiators {
-		if r.getPortType(initiator.PortName.ValueString()) != string(gopowerstore.InitiatorProtocolTypeEnumISCSI) && !(initiator.ChapSingleUsername.IsNull() && initiator.ChapMutualUsername.IsNull() && initiator.ChapMutualPassword.IsNull() && initiator.ChapSinglePassword.IsNull()) {
+		// PortName is required. It can be unknown, but not null. Ignore if unknown.
+		if !initiator.PortName.IsUnknown() &&
+			// if port type is not iSCSI then check further
+			r.getPortType(initiator.PortName.ValueString()) != string(gopowerstore.InitiatorProtocolTypeEnumISCSI) &&
+			// check if any of the chap creds have not been configured
+			(helper.IsKnownValue(initiator.ChapSingleUsername) ||
+				helper.IsKnownValue(initiator.ChapMutualUsername) ||
+				helper.IsKnownValue(initiator.ChapMutualPassword) ||
+				helper.IsKnownValue(initiator.ChapSinglePassword)) {
 			resp.Diagnostics.AddError(
 				"Error validating config host",
 				"chap credentials are supported only with iSCSI protocol",
 			)
 		}
-		if initiator.ChapMutualUsername != types.StringNull() && initiator.ChapSingleUsername == types.StringNull() {
+		if helper.IsKnownValue(initiator.ChapMutualUsername) && initiator.ChapSingleUsername.IsNull() {
 			resp.Diagnostics.AddError(
 				"Error validating config host",
-				"`chap_mutual_username` cannot pe present without `chap_single_username`",
+				"`chap_mutual_username` cannot be present without `chap_single_username`",
 			)
 		}
-		if initiator.ChapMutualUsername == types.StringNull() && initiator.ChapMutualPassword != types.StringNull() {
+		if helper.IsKnownValue(initiator.ChapMutualPassword) && initiator.ChapSinglePassword.IsNull() {
 			resp.Diagnostics.AddError(
 				"Error validating config host",
-				"`chap_mutual_password` cannot pe present without `chap_mutual_username`",
+				"`chap_mutual_password` cannot be present without `chap_mutual_username`",
 			)
 		}
-		if initiator.ChapSingleUsername == types.StringNull() && initiator.ChapSinglePassword != types.StringNull() {
+		if helper.IsKnownValue(initiator.ChapSinglePassword) && initiator.ChapSingleUsername.IsNull() {
 			resp.Diagnostics.AddError(
 				"Error validating config host",
-				"`chap_single_password` cannot pe present without `chap_single_username`",
+				"`chap_single_password` cannot be present without `chap_single_username`",
 			)
 		}
 	}

--- a/powerstore/resource_host_test.go
+++ b/powerstore/resource_host_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+Copyright (c) 2024-2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 
 Licensed under the Mozilla Public License Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -231,196 +231,196 @@ func TestAccHost_Validations(t *testing.T) {
 			// validate with known port name and valid unknown chap creds
 			{
 				Config: ProviderConfigForTesting + `
-								resource terraform_data username {
-									input = null
-								}
-								resource "powerstore_host" "test" {
-									name = "tf_host_acc_new"
-									description = "Test Host Resource"
-									os_type = "Linux"
-									initiators = [{
-										port_name = "nqn.1994-05.com.redhat:88cb606"
-										chap_single_username = terraform_data.username.output
-										chap_single_password = terraform_data.username.output
-										chap_mutual_username = terraform_data.username.output
-										chap_mutual_password = terraform_data.username.output
-									}]
-								}
-								`,
+					resource terraform_data username {
+						input = null
+					}
+					resource "powerstore_host" "test" {
+						name = "tf_host_acc_new"
+						description = "Test Host Resource"
+						os_type = "Linux"
+						initiators = [{
+							port_name = "nqn.1994-05.com.redhat:88cb606"
+							chap_single_username = terraform_data.username.output
+							chap_single_password = terraform_data.username.output
+							chap_mutual_username = terraform_data.username.output
+							chap_mutual_password = terraform_data.username.output
+						}]
+					}
+					`,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
 			// validate with unknown iSCSI port name and known chap creds
 			{
 				Config: ProviderConfigForTesting + `
-								resource terraform_data portname {
-									input = "iqn.port"
-								}
-								resource "powerstore_host" "test" {
-									name = "tf_host_acc_new"
-									description = "Test Host Resource"
-									os_type = "Linux"
-									initiators = [{
-										port_name = terraform_data.portname.output
-										chap_single_username = "whatever"
-										chap_single_password = "whatever"
-										chap_mutual_username = "whatever"
-										chap_mutual_password = "whatever"
-									}]
-								}
-								`,
+					resource terraform_data portname {
+						input = "iqn.port"
+					}
+					resource "powerstore_host" "test" {
+						name = "tf_host_acc_new"
+						description = "Test Host Resource"
+						os_type = "Linux"
+						initiators = [{
+							port_name = terraform_data.portname.output
+							chap_single_username = "whatever"
+							chap_single_password = "whatever"
+							chap_mutual_username = "whatever"
+							chap_mutual_password = "whatever"
+						}]
+					}
+					`,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
 			// validate with unknown iSCSI port name and unknown chap creds
 			{
 				Config: ProviderConfigForTesting + `
-								resource terraform_data portname {
-									input = "iqn.port"
-								}
-								resource terraform_data username {
-									input = null
-								}
-								resource "powerstore_host" "test" {
-									name = "tf_host_acc_new"
-									description = "Test Host Resource"
-									os_type = "Linux"
-									initiators = [{
-										port_name = terraform_data.portname.output
-										chap_single_username = terraform_data.username.output
-										chap_single_password = terraform_data.username.output
-										chap_mutual_username = terraform_data.username.output
-										chap_mutual_password = terraform_data.username.output
-									}]
-								}
-								`,
+					resource terraform_data portname {
+						input = "iqn.port"
+					}
+					resource terraform_data username {
+						input = null
+					}
+					resource "powerstore_host" "test" {
+						name = "tf_host_acc_new"
+						description = "Test Host Resource"
+						os_type = "Linux"
+						initiators = [{
+							port_name = terraform_data.portname.output
+							chap_single_username = terraform_data.username.output
+							chap_single_password = terraform_data.username.output
+							chap_mutual_username = terraform_data.username.output
+							chap_mutual_password = terraform_data.username.output
+						}]
+					}
+					`,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
 			// validate with known nvme port name and known chap creds - neg
 			{
 				Config: ProviderConfigForTesting + `
-								resource "powerstore_host" "test" {
-									name = "tf_host_acc_new"
-									description = "Test Host Resource"
-									os_type = "Linux"
-									initiators = [{
-										port_name = "nqn.1994-05.com.redhat:88cb606"
-										chap_single_username = "whatever"
-										chap_single_password = "whatever"
-										chap_mutual_username = "whatever"
-										chap_mutual_password = "whatever"
-									}]
-								}
-								`,
+					resource "powerstore_host" "test" {
+						name = "tf_host_acc_new"
+						description = "Test Host Resource"
+						os_type = "Linux"
+						initiators = [{
+							port_name = "nqn.1994-05.com.redhat:88cb606"
+							chap_single_username = "whatever"
+							chap_single_password = "whatever"
+							chap_mutual_username = "whatever"
+							chap_mutual_password = "whatever"
+						}]
+					}
+					`,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile("chap credentials are supported only with iSCSI protocol"),
 			},
 			// validate that chap creds work in loops
 			{
 				Config: ProviderConfigForTesting + `
-								resource "powerstore_host" "test" {
-									for_each = tomap({
-										"192.168.10.156" = "iqn.1993-08.org.debian.iscsi:01:107dc7e4254a"
-										"192.168.10.157" = "iqn.1993-08.org.debian.iscsi:01:107dc7e4254b"
-									})
-									name              = each.key
-									os_type           = "ESXi"
-									host_connectivity = "Local_Only"
-									description       = each.value
-									initiators =  [{port_name = "${each.value}", chap_single_username = "testuser", chap_single_password = "testuser123"}]
-								}
-								`,
+					resource "powerstore_host" "test" {
+						for_each = tomap({
+							"192.168.10.156" = "iqn.1993-08.org.debian.iscsi:01:107dc7e4254a"
+							"192.168.10.157" = "iqn.1993-08.org.debian.iscsi:01:107dc7e4254b"
+						})
+						name              = each.key
+						os_type           = "ESXi"
+						host_connectivity = "Local_Only"
+						description       = each.value
+						initiators =  [{port_name = "${each.value}", chap_single_username = "testuser", chap_single_password = "testuser123"}]
+					}
+					`,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
 			// validate chap_mutual_username cannot be present without chap_single_username - neg
 			{
 				Config: ProviderConfigForTesting + `
-								resource "powerstore_host" "test" {
-									name = "tf_host_acc_new"
-									description = "Test Host Resource"
-									os_type = "Linux"
-									initiators = [{
-										port_name = "iqn.1994-05.com.redhat:88cb606"
-										chap_mutual_username = "whatever"
-									}]
-								}
-								`,
+					resource "powerstore_host" "test" {
+						name = "tf_host_acc_new"
+						description = "Test Host Resource"
+						os_type = "Linux"
+						initiators = [{
+							port_name = "iqn.1994-05.com.redhat:88cb606"
+							chap_mutual_username = "whatever"
+						}]
+					}
+					`,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile("chap_mutual_username.*cannot be present without.*chap_single_username"),
 			},
 			// validate chap_mutual_password cannot be present without chap_mutual_username - neg
 			{
 				Config: ProviderConfigForTesting + `
-								resource "powerstore_host" "test" {
-									name = "tf_host_acc_new"
-									description = "Test Host Resource"
-									os_type = "Linux"
-									initiators = [{
-										port_name = "iqn.1994-05.com.redhat:88cb606"
-										chap_mutual_password = "whatever"
-									}]
-								}
-								`,
+					resource "powerstore_host" "test" {
+						name = "tf_host_acc_new"
+						description = "Test Host Resource"
+						os_type = "Linux"
+						initiators = [{
+							port_name = "iqn.1994-05.com.redhat:88cb606"
+							chap_mutual_password = "whatever"
+						}]
+					}
+					`,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile("chap_mutual_password.*cannot be present without.*chap_mutual_username"),
 			},
 			// validate chap_single_password cannot be present without chap_single_username - neg
 			{
 				Config: ProviderConfigForTesting + `
-								resource "powerstore_host" "test" {
-									name = "tf_host_acc_new"
-									description = "Test Host Resource"
-									os_type = "Linux"
-									initiators = [{
-										port_name = "iqn.1994-05.com.redhat:88cb606"
-										chap_single_password = "whatever"
-									}]
-								}
-								`,
+					resource "powerstore_host" "test" {
+						name = "tf_host_acc_new"
+						description = "Test Host Resource"
+						os_type = "Linux"
+						initiators = [{
+							port_name = "iqn.1994-05.com.redhat:88cb606"
+							chap_single_password = "whatever"
+						}]
+					}
+					`,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile("chap_single_password.*cannot be present without.*chap_single_username"),
 			},
 			// validate with unknown null chap passwords
 			{
 				Config: ProviderConfigForTesting + `
-								resource terraform_data password {
-									input = null
-								}
-								resource "powerstore_host" "test" {
-									name = "tf_host_acc_new"
-									description = "Test Host Resource"
-									os_type = "Linux"
-									initiators = [{
-										port_name = "iqn.1994-05.com.redhat:88cb606"
-										chap_single_username = "whatever"
-										chap_single_password = terraform_data.password.output
-										chap_mutual_username = "whatever"
-										chap_mutual_password = terraform_data.password.output
-									}]
-								}
-								`,
+					resource terraform_data password {
+						input = null
+					}
+					resource "powerstore_host" "test" {
+						name = "tf_host_acc_new"
+						description = "Test Host Resource"
+						os_type = "Linux"
+						initiators = [{
+							port_name = "iqn.1994-05.com.redhat:88cb606"
+							chap_single_username = "whatever"
+							chap_single_password = terraform_data.password.output
+							chap_mutual_username = "whatever"
+							chap_mutual_password = terraform_data.password.output
+						}]
+					}
+					`,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
 			// validate with unknown non-null chap single username
 			{
 				Config: ProviderConfigForTesting + `
-								resource terraform_data username {
-									input = "whatever"
-								}
-								resource "powerstore_host" "test" {
-									name = "tf_host_acc_new"
-									description = "Test Host Resource"
-									os_type = "Linux"
-									initiators = [{
-										port_name = "iqn.1994-05.com.redhat:88cb606"
-										chap_single_username = terraform_data.username.output
-										chap_mutual_username = "whatever"
-									}]
-								}
-								`,
+					resource terraform_data username {
+						input = "whatever"
+					}
+					resource "powerstore_host" "test" {
+						name = "tf_host_acc_new"
+						description = "Test Host Resource"
+						os_type = "Linux"
+						initiators = [{
+							port_name = "iqn.1994-05.com.redhat:88cb606"
+							chap_single_username = terraform_data.username.output
+							chap_mutual_username = "whatever"
+						}]
+					}
+					`,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},


### PR DESCRIPTION
# Description
1. Fix Host Resource validator to allow unknowns - Fixing https://github.com/dell/terraform-provider-powerstore/issues/130
2. Add error for key-only filter expression. This is a basic validation to say that the query string follows `k=v` format.
Otherwise, a string like `whatever` or `whatever=` or `name=rounak&whatever` is accepted by our provider.
Interestingly, this will also be accepted by the powerstore API and all results of the collection would be returned, which is not ideal.



# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/terraform-provider-powerstore/issues/130 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Acceptance tests
- [x] Unit Tests

# Code Coverage

![image](https://github.com/user-attachments/assets/61c092c8-9541-4385-bc24-7b8e4023691c)
