### PR TITLE
Adding Specific-field-output examples

### DIFF
--- a/docs/data-sources/filesystem.md
+++ b/docs/data-sources/filesystem.md
@@ -92,9 +92,24 @@ data "powerstore_filesystem" "file_systems_us_east" {
 data "powerstore_filesystem" "all_file_systems" {
 }
 
-
-output "result" {
+// Output all filesystem details
+output "filesystem_all_details" {
   value = data.powerstore_filesystem.all_file_systems.filesystems
+}
+
+// Output only filesystem names
+output "filesystem_names_only" {
+  value = data.powerstore_filesystem.all_file_systems.filesystems.*.name
+}
+
+// Output filesystem name and access policy with filesystem id as key
+output "name_and_access_policy" {
+  value = {
+    for filesystem in data.powerstore_filesystem.all_file_systems.filesystems : filesystem.id => {
+      name = filesystem.name
+      access_policy = filesystem.access_policy
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/filesystem_snapshot.md
+++ b/docs/data-sources/filesystem_snapshot.md
@@ -120,9 +120,24 @@ data "powerstore_filesystem_snapshot" "user_or_root_created_snapshots" {
 data "powerstore_filesystem_snapshot" "all" {
 }
 
+// Output all filesystem snapshot details
+output "filesystem_snapshot_all_details" {
+  value = data.powerstore_filesystem_snapshot.all.filesystem_snapshots
+}
 
-output "result" {
-  value = data.powerstore_filesystem_snapshot.all.filesystems
+// Output only filesystem snapshot IDs
+output "filesystem_snapshot_IDs_only" {
+  value = data.powerstore_filesystem_snapshot.all.filesystem_snapshots.*.id
+}
+
+// Output filesystem snapshot name and size used with filesystem snapshot id as key
+output "filesystem_snapshot_name_and_size_used" {
+  value = {
+    for filesystem_snapshot in data.powerstore_filesystem_snapshot.all.filesystem_snapshots : filesystem_snapshot.id => {
+      name = filesystem_snapshot.name
+      size_used = filesystem_snapshot.size_used
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/host.md
+++ b/docs/data-sources/host.md
@@ -63,8 +63,27 @@ data "powerstore_host" "test1" {
   name = "tf_host"
 }
 
-output "hostResult" {
-  value = data.powerstore_host.test1.hosts
+data "powerstore_host" "all"{
+}
+
+# Output all host details
+output "host_all_details" {
+  value = data.powerstore_host.all.host
+}
+
+# Output only host IDs
+output "host_IDs_only" {
+  value = data.powerstore_host.all.host.*.id
+}
+
+# Ouptput host name and os type with host id as key
+output "host_name_and_os_type" {
+    value = {
+    for host in data.powerstore_host.all.host : host.id => {
+      name = host.name
+      os_type = host.os_type
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/hostgroup.md
+++ b/docs/data-sources/hostgroup.md
@@ -63,8 +63,27 @@ data "powerstore_hostgroup" "test1" {
   name = "test_hostgroup1"
 }
 
-output "hostGroupResult" {
-  value = data.powerstore_hostgroup.test1.host_groups
+data "powerstore_hostgroup" "all" {
+}
+
+# Output all host group details
+output "host_group_all_details" {
+  value = data.powerstore_hostgroup.all.host_groups
+}
+
+# Output only host group names
+output "host_group_names_only" {
+  value = data.powerstore_hostgroup.all.host_groups.*.name
+}
+
+# Ouptput host name and os type with host group id as key
+output "hostgroup_name_and_host_connectivity" {
+    value = {
+    for hostgroup in data.powerstore_hostgroup.all.host_groups : hostgroup.id => {
+      name = hostgroup.name
+      host_connectivity = hostgroup.host_connectivity 
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/nas_server.md
+++ b/docs/data-sources/nas_server.md
@@ -72,8 +72,24 @@ data "powerstore_nas_server" "nas_server_by_filter" {
   filter_expression = "and=(operational_status.eq.Started, is_replication_destination.eq.false)"
 }
 
-output "powerstore_nas_server" {
+# Output all NAS Server details
+output "nas_server_all_details" {
   value = data.powerstore_nas_server.all.nas_servers
+}
+
+# Output only NAS Server IDs
+output "nas_server_IDs_only" {
+  value = data.powerstore_nas_server.all.nas_servers.*.id
+}
+
+# Output NAS Server name and current node ID with nas server ID as key
+output "nas_server_name_and_current_node_id" {
+  value = {
+    for nas_server in data.powerstore_nas_server.all.nas_servers : nas_server.id => {
+      name = nas_server.name
+      current_node_id = nas_server.current_node_id  
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/nfs_export.md
+++ b/docs/data-sources/nfs_export.md
@@ -93,8 +93,24 @@ data "powerstore_nfs_export" "nfs_export_by_name_regex" {
   filter_expression = "path=ilike./us-east-revenue/sports_cars/*&min_security=eq.Sys&default_access=eq.Root"
 }
 
-output "nfs_exports_with_name_regex" {
+# Output all NFS Export Details
+output "nfs_export_all_details" {
   value = data.powerstore_nfs_export.nfs_export_by_name_regex.nfs_exports
+}
+
+# Output only NFS Export names
+output "all_details" {
+  value = data.powerstore_nfs_export.nfs_export_by_name_regex.nfs_exports.*.name
+}
+
+# Output NFS Export IDs and paths with NFS Export name as key
+output "nfs_export_name_and_path" {
+  value = {
+    for nfs_export in data.powerstore_nfs_export.nfs_export_by_name_regex.nfs_exports : nfs_export.name => {
+      name = nfs_export.id
+      path = nfs_export.path  
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/protectionpolicy.md
+++ b/docs/data-sources/protectionpolicy.md
@@ -63,8 +63,24 @@ data "powerstore_protectionpolicy" "test1" {
   name = "terraform_protection_policy_2"
 }
 
-output "policyResult" {
+# Output all Protection Policy Details
+output "protection_policy_all_details" {
   value = data.powerstore_protectionpolicy.test1.policies
+}
+
+# Output only Protection Policy names
+output "protection_policy_names_only" {
+  value = data.powerstore_protectionpolicy.test1.policies.*.name
+}
+
+# Output Protection Policy IDs and volumes with Protection Policy name as key
+output "nfs_export_name_and_path" {
+  value = {
+    for policy in data.powerstore_protectionpolicy.test1.policies : policy.name => {
+      name = policy.id
+      volumes = policy.volumes  
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/remote_system.md
+++ b/docs/data-sources/remote_system.md
@@ -71,8 +71,24 @@ data "powerstore_remote_system" "remote_system_by_filters" {
   filter_expression = "management_address=eq.10.225.225.10"
 }
 
-output "all_remote_systems" {
+# Output all Remote System Details
+output "remote_systems_all_details" {
   value = data.powerstore_remote_system.all_remote_systems.remote_systems
+}
+
+# Output only Remote System IDs
+output "remote_systems_IDs_only" {
+  value = data.powerstore_remote_system.all_remote_systems.remote_systems.*.id
+}
+
+# Output Remote System capabilities and serial numbers with Remote System name as key
+output "remote_system_capabilities_and_serial_number" {
+  value = {
+    for remote_system in data.powerstore_remote_system.all_remote_systems.remote_systems : remote_system.name => {
+      capabilities = remote_system.capabilities
+      serial_number = remote_system.serial_number
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/replication_rule.md
+++ b/docs/data-sources/replication_rule.md
@@ -73,8 +73,24 @@ data "powerstore_replication_rule" "rule_by_filter" {
   filter_expression = "and=(name.ilike.sample*, managed_by.eq.User)"
 }
 
-output "replicationRule" {
+# Output all Replication Rules Details
+output "replication_rules_all_details" {
   value = data.powerstore_replication_rule.all.replication_rules
+}
+
+# Output only Replication Rule IDs
+output "replication_rules_IDs_only" {
+  value = data.powerstore_replication_rule.all.replication_rules.*.id
+}
+
+# Output Replication Rule IDs and policies with Replication Rule name as key
+output "replication_rule_id_and_policies" {
+  value = {
+    for rule in data.powerstore_replication_rule.all.replication_rules : rule.name => {
+      id = rule.id
+      policies = rule.policies
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/smb_share.md
+++ b/docs/data-sources/smb_share.md
@@ -89,8 +89,24 @@ data "powerstore_smb_share" "smb_share_by_filters" {
   filter_expression = "path=ilike./us-east-revenue/sports_cars/*&is_encryption_enabled=is.true&offline_availability=in.(Documents,None)"
 }
 
-output "all_smb_shares" {
+# Output all SMB Shares Details
+output "smb_shares_all_details" {
   value = data.powerstore_smb_share.all_smb_shares.smb_shares
+}
+
+# Output only Replication share IDs
+output "smb_shares_IDs_only" {
+  value = data.powerstore_smb_share.all_smb_shares.smb_shares.*.id
+}
+
+# Output Replication share IDs and policies with Replication share ID as key
+output "smb_shares_id_and_policies" {
+  value = {
+    for share in data.powerstore_smb_share.all_smb_shares.smb_shares : share.id => {
+      file_system_id = share.file_system_id
+      path = share.path
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/snapshotrule.md
+++ b/docs/data-sources/snapshotrule.md
@@ -64,8 +64,24 @@ data "powerstore_snapshotrule" "test1" {
   name = "test_snapshotrule_1"
 }
 
-output "snapshotRule" {
+# Output all Snapshot Rules Details
+output "snapshotRules_all_details" {
   value = data.powerstore_snapshotrule.test1.snapshot_rules
+}
+
+# Output only Snapshot Rule IDs
+output "snapshot_rules_IDs_only" {
+  value = data.powerstore_snapshotrule.test1.snapshot_rules.*.id
+}
+
+# Output Snapshot Rule names and timezone with Snapshot Rule id as key
+output "snapshot_rule_name_and_timezone" {
+  value = {
+    for rule in data.powerstore_snapshotrule.test1.snapshot_rules : rule.id => {
+      name = rule.name
+      timezone = rule.timezone
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/volume.md
+++ b/docs/data-sources/volume.md
@@ -64,8 +64,24 @@ data "powerstore_volume" "volume_by_filter" {
   filter_expression = "and=(is_replication_destination.eq.false, name.ilike.*vol*)"
 }
 
-output "volumeResult" {
+# Output all Volume Details
+output "volume_all_details" {
   value = data.powerstore_volume.test1.volumes
+}
+
+# Output only Volume IDs
+output "volumes_IDs_only" {
+  value = data.powerstore_volume.test1.volumes.*.id
+}
+
+# Output Volume IDs and sizes with Volume name as key
+output "volume_id_and_size" {
+  value = {
+    for volume in data.powerstore_volume.test1.volumes : volume.name => {
+      id = volume.id
+      size = volume.size
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/volume_snapshot.md
+++ b/docs/data-sources/volume_snapshot.md
@@ -65,8 +65,24 @@ data "powerstore_volume_snapshot" "volume_snapshot_by_filter" {
   filter_expression = "and=(is_replication_destination.eq.false, state_l10n.eq.Ready)"
 }
 
-output "volumeSnapshotResult" {
+# Output all Volume Snapshot Details
+output "volume_snapshot_all_details" {
   value = data.powerstore_volume_snapshot.test1.volumes
+}
+
+# Output only Volume Snapshot IDs
+output "volume_snapshot_IDs_only" {
+  value = data.powerstore_volume_snapshot.test1.volumes.*.id
+}
+
+# Output Volume Snapshot IDs and sizes with Volume Snapshot name as key
+output "volume_snapshot_id_and_size" {
+  value = {
+    for volume_snapshot in data.powerstore_volume_snapshot.test1.volumes : volume_snapshot.name => {
+      id = volume_snapshot.id
+      size = volume_snapshot.size
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/volumegroup.md
+++ b/docs/data-sources/volumegroup.md
@@ -74,8 +74,24 @@ data "powerstore_volumegroup" "filter" {
   filter_expression = "name=ilike.vg*"
 }
 
-output "volumeGroupResult" {
+# Output all Volume Group Details
+output "volumegroup_all_details" {
   value = data.powerstore_volumegroup.all.volume_groups
+}
+
+# Output only Volume Group names
+output "volume_group_names_only" {
+  value = data.powerstore_volumegroup.all.volume_groups.*.name
+}
+
+# Output Volume Group creation_timestamps and location_history with Volume Group ID as key
+output "volume_group_id_and_size" {
+  value = {
+    for volume_group in data.powerstore_volumegroup.all.volume_groups : volume_group.id => {
+      creation_timestamp  = volume_group.creation_timestamp 
+      location_history  = volume_group.location_history 
+    }
+  }
 }
 ```
 

--- a/docs/data-sources/volumegroup_snapshot.md
+++ b/docs/data-sources/volumegroup_snapshot.md
@@ -73,8 +73,25 @@ data "powerstore_volumegroup_snapshot" "filter" {
   filter_expression = "name=ilike.snap"
 }
 
-output "volumeGroupSnapshotResult" {
+# Output all Volume Group Snapshot Details
+output "volumegroupSnapshot_all_details" {
   value = data.powerstore_volumegroup_snapshot.all.volume_groups
+}
+
+
+# Output only Volume Group names
+output "volumeGroupSnapshot_names_only" {
+  value = data.powerstore_volumegroup_snapshot.all.volume_groups.*.name
+}
+
+# Output Volume Group Snapshot creation_timestamps and location_history with Volume Group Snapshot ID as key
+output "volumeGroupSnapshot_id_and_size" {
+  value = {
+    for volume_group in data.powerstore_volumegroup_snapshot.all.volume_groups : volume_group.id => {
+      creation_timestamp  = volume_group.creation_timestamp 
+      location_history  = volume_group.location_history 
+    }
+  }
 }
 ```
 

--- a/examples/data-sources/powerstore_filesystem/data-source.tf
+++ b/examples/data-sources/powerstore_filesystem/data-source.tf
@@ -61,7 +61,22 @@ data "powerstore_filesystem" "file_systems_us_east" {
 data "powerstore_filesystem" "all_file_systems" {
 }
 
-
-output "result" {
+// Output all filesystem details
+output "filesystem_all_details" {
   value = data.powerstore_filesystem.all_file_systems.filesystems
+}
+
+// Output only filesystem names
+output "filesystem_names_only" {
+  value = data.powerstore_filesystem.all_file_systems.filesystems.*.name
+}
+
+// Output filesystem name and access policy with filesystem id as key
+output "name_and_access_policy" {
+  value = {
+    for filesystem in data.powerstore_filesystem.all_file_systems.filesystems : filesystem.id => {
+      name = filesystem.name
+      access_policy = filesystem.access_policy
+    }
+  }
 }

--- a/examples/data-sources/powerstore_filesystem_snapshot/data-source.tf
+++ b/examples/data-sources/powerstore_filesystem_snapshot/data-source.tf
@@ -87,7 +87,22 @@ data "powerstore_filesystem_snapshot" "user_or_root_created_snapshots" {
 data "powerstore_filesystem_snapshot" "all" {
 }
 
+// Output all filesystem snapshot details
+output "filesystem_snapshot_all_details" {
+  value = data.powerstore_filesystem_snapshot.all.filesystem_snapshots
+}
 
-output "result" {
-  value = data.powerstore_filesystem_snapshot.all.filesystems
+// Output only filesystem snapshot IDs
+output "filesystem_snapshot_IDs_only" {
+  value = data.powerstore_filesystem_snapshot.all.filesystem_snapshots.*.id
+}
+
+// Output filesystem snapshot name and size used with filesystem snapshot id as key
+output "filesystem_snapshot_name_and_size_used" {
+  value = {
+    for filesystem_snapshot in data.powerstore_filesystem_snapshot.all.filesystem_snapshots : filesystem_snapshot.id => {
+      name = filesystem_snapshot.name
+      size_used = filesystem_snapshot.size_used
+    }
+  }
 }

--- a/examples/data-sources/powerstore_host/data-source.tf
+++ b/examples/data-sources/powerstore_host/data-source.tf
@@ -30,6 +30,25 @@ data "powerstore_host" "test1" {
   name = "tf_host"
 }
 
-output "hostResult" {
-  value = data.powerstore_host.test1.hosts
+data "powerstore_host" "all"{
+}
+
+# Output all host details
+output "host_all_details" {
+  value = data.powerstore_host.all.host
+}
+
+# Output only host IDs
+output "host_IDs_only" {
+  value = data.powerstore_host.all.host.*.id
+}
+
+# Ouptput host name and os type with host id as key
+output "host_name_and_os_type" {
+    value = {
+    for host in data.powerstore_host.all.host : host.id => {
+      name = host.name
+      os_type = host.os_type
+    }
+  }
 }

--- a/examples/data-sources/powerstore_hostgroup/data-source.tf
+++ b/examples/data-sources/powerstore_hostgroup/data-source.tf
@@ -30,6 +30,25 @@ data "powerstore_hostgroup" "test1" {
   name = "test_hostgroup1"
 }
 
-output "hostGroupResult" {
-  value = data.powerstore_hostgroup.test1.host_groups
+data "powerstore_hostgroup" "all" {
+}
+
+# Output all host group details
+output "host_group_all_details" {
+  value = data.powerstore_hostgroup.all.host_groups
+}
+
+# Output only host group names
+output "host_group_names_only" {
+  value = data.powerstore_hostgroup.all.host_groups.*.name
+}
+
+# Ouptput host name and os type with host group id as key
+output "hostgroup_name_and_host_connectivity" {
+    value = {
+    for hostgroup in data.powerstore_hostgroup.all.host_groups : hostgroup.id => {
+      name = hostgroup.name
+      host_connectivity = hostgroup.host_connectivity 
+    }
+  }
 }

--- a/examples/data-sources/powerstore_nas_server/data-source.tf
+++ b/examples/data-sources/powerstore_nas_server/data-source.tf
@@ -41,6 +41,22 @@ data "powerstore_nas_server" "nas_server_by_filter" {
   filter_expression = "and=(operational_status.eq.Started, is_replication_destination.eq.false)"
 }
 
-output "powerstore_nas_server" {
+# Output all NAS Server details
+output "nas_server_all_details" {
   value = data.powerstore_nas_server.all.nas_servers
+}
+
+# Output only NAS Server IDs
+output "nas_server_IDs_only" {
+  value = data.powerstore_nas_server.all.nas_servers.*.id
+}
+
+# Output NAS Server name and current node ID with nas server ID as key
+output "nas_server_name_and_current_node_id" {
+  value = {
+    for nas_server in data.powerstore_nas_server.all.nas_servers : nas_server.id => {
+      name = nas_server.name
+      current_node_id = nas_server.current_node_id  
+    }
+  }
 }

--- a/examples/data-sources/powerstore_nfs_export/data-source.tf
+++ b/examples/data-sources/powerstore_nfs_export/data-source.tf
@@ -60,6 +60,22 @@ data "powerstore_nfs_export" "nfs_export_by_name_regex" {
   filter_expression = "path=ilike./us-east-revenue/sports_cars/*&min_security=eq.Sys&default_access=eq.Root"
 }
 
-output "nfs_exports_with_name_regex" {
+# Output all NFS Export Details
+output "nfs_export_all_details" {
   value = data.powerstore_nfs_export.nfs_export_by_name_regex.nfs_exports
+}
+
+# Output only NFS Export names
+output "all_details" {
+  value = data.powerstore_nfs_export.nfs_export_by_name_regex.nfs_exports.*.name
+}
+
+# Output NFS Export IDs and paths with NFS Export name as key
+output "nfs_export_name_and_path" {
+  value = {
+    for nfs_export in data.powerstore_nfs_export.nfs_export_by_name_regex.nfs_exports : nfs_export.name => {
+      name = nfs_export.id
+      path = nfs_export.path  
+    }
+  }
 }

--- a/examples/data-sources/powerstore_protectionpolicy/data-source.tf
+++ b/examples/data-sources/powerstore_protectionpolicy/data-source.tf
@@ -30,6 +30,22 @@ data "powerstore_protectionpolicy" "test1" {
   name = "terraform_protection_policy_2"
 }
 
-output "policyResult" {
+# Output all Protection Policy Details
+output "protection_policy_all_details" {
   value = data.powerstore_protectionpolicy.test1.policies
+}
+
+# Output only Protection Policy names
+output "protection_policy_names_only" {
+  value = data.powerstore_protectionpolicy.test1.policies.*.name
+}
+
+# Output Protection Policy IDs and volumes with Protection Policy name as key
+output "nfs_export_name_and_path" {
+  value = {
+    for policy in data.powerstore_protectionpolicy.test1.policies : policy.name => {
+      name = policy.id
+      volumes = policy.volumes  
+    }
+  }
 }

--- a/examples/data-sources/powerstore_remote_system/data-source.tf
+++ b/examples/data-sources/powerstore_remote_system/data-source.tf
@@ -38,6 +38,22 @@ data "powerstore_remote_system" "remote_system_by_filters" {
   filter_expression = "management_address=eq.10.225.225.10"
 }
 
-output "all_remote_systems" {
+# Output all Remote System Details
+output "remote_systems_all_details" {
   value = data.powerstore_remote_system.all_remote_systems.remote_systems
+}
+
+# Output only Remote System IDs
+output "remote_systems_IDs_only" {
+  value = data.powerstore_remote_system.all_remote_systems.remote_systems.*.id
+}
+
+# Output Remote System capabilities and serial numbers with Remote System name as key
+output "remote_system_capabilities_and_serial_number" {
+  value = {
+    for remote_system in data.powerstore_remote_system.all_remote_systems.remote_systems : remote_system.name => {
+      capabilities = remote_system.capabilities
+      serial_number = remote_system.serial_number
+    }
+  }
 }

--- a/examples/data-sources/powerstore_replication_rule/data-source.tf
+++ b/examples/data-sources/powerstore_replication_rule/data-source.tf
@@ -40,6 +40,22 @@ data "powerstore_replication_rule" "rule_by_filter" {
   filter_expression = "and=(name.ilike.sample*, managed_by.eq.User)"
 }
 
-output "replicationRule" {
+# Output all Replication Rules Details
+output "replication_rules_all_details" {
   value = data.powerstore_replication_rule.all.replication_rules
+}
+
+# Output only Replication Rule IDs
+output "replication_rules_IDs_only" {
+  value = data.powerstore_replication_rule.all.replication_rules.*.id
+}
+
+# Output Replication Rule IDs and policies with Replication Rule name as key
+output "replication_rule_id_and_policies" {
+  value = {
+    for rule in data.powerstore_replication_rule.all.replication_rules : rule.name => {
+      id = rule.id
+      policies = rule.policies
+    }
+  }
 }

--- a/examples/data-sources/powerstore_smb_share/data-source.tf
+++ b/examples/data-sources/powerstore_smb_share/data-source.tf
@@ -56,6 +56,22 @@ data "powerstore_smb_share" "smb_share_by_filters" {
   filter_expression = "path=ilike./us-east-revenue/sports_cars/*&is_encryption_enabled=is.true&offline_availability=in.(Documents,None)"
 }
 
-output "all_smb_shares" {
+# Output all SMB Shares Details
+output "smb_shares_all_details" {
   value = data.powerstore_smb_share.all_smb_shares.smb_shares
+}
+
+# Output only Replication share IDs
+output "smb_shares_IDs_only" {
+  value = data.powerstore_smb_share.all_smb_shares.smb_shares.*.id
+}
+
+# Output Replication share IDs and policies with Replication share ID as key
+output "smb_shares_id_and_policies" {
+  value = {
+    for share in data.powerstore_smb_share.all_smb_shares.smb_shares : share.id => {
+      file_system_id = share.file_system_id
+      path = share.path
+    }
+  }
 }

--- a/examples/data-sources/powerstore_snapshotrule/data-source.tf
+++ b/examples/data-sources/powerstore_snapshotrule/data-source.tf
@@ -31,6 +31,22 @@ data "powerstore_snapshotrule" "test1" {
   name = "test_snapshotrule_1"
 }
 
-output "snapshotRule" {
+# Output all Snapshot Rules Details
+output "snapshotRules_all_details" {
   value = data.powerstore_snapshotrule.test1.snapshot_rules
+}
+
+# Output only Snapshot Rule IDs
+output "snapshot_rules_IDs_only" {
+  value = data.powerstore_snapshotrule.test1.snapshot_rules.*.id
+}
+
+# Output Snapshot Rule names and timezone with Snapshot Rule id as key
+output "snapshot_rule_name_and_timezone" {
+  value = {
+    for rule in data.powerstore_snapshotrule.test1.snapshot_rules : rule.id => {
+      name = rule.name
+      timezone = rule.timezone
+    }
+  }
 }

--- a/examples/data-sources/powerstore_volume/data-source.tf
+++ b/examples/data-sources/powerstore_volume/data-source.tf
@@ -31,6 +31,22 @@ data "powerstore_volume" "volume_by_filter" {
   filter_expression = "and=(is_replication_destination.eq.false, name.ilike.*vol*)"
 }
 
-output "volumeResult" {
+# Output all Volume Details
+output "volume_all_details" {
   value = data.powerstore_volume.test1.volumes
+}
+
+# Output only Volume IDs
+output "volumes_IDs_only" {
+  value = data.powerstore_volume.test1.volumes.*.id
+}
+
+# Output Volume IDs and sizes with Volume name as key
+output "volume_id_and_size" {
+  value = {
+    for volume in data.powerstore_volume.test1.volumes : volume.name => {
+      id = volume.id
+      size = volume.size
+    }
+  }
 }

--- a/examples/data-sources/powerstore_volume_snapshot/data-source.tf
+++ b/examples/data-sources/powerstore_volume_snapshot/data-source.tf
@@ -32,6 +32,22 @@ data "powerstore_volume_snapshot" "volume_snapshot_by_filter" {
   filter_expression = "and=(is_replication_destination.eq.false, state_l10n.eq.Ready)"
 }
 
-output "volumeSnapshotResult" {
+# Output all Volume Snapshot Details
+output "volume_snapshot_all_details" {
   value = data.powerstore_volume_snapshot.test1.volumes
+}
+
+# Output only Volume Snapshot IDs
+output "volume_snapshot_IDs_only" {
+  value = data.powerstore_volume_snapshot.test1.volumes.*.id
+}
+
+# Output Volume Snapshot IDs and sizes with Volume Snapshot name as key
+output "volume_snapshot_id_and_size" {
+  value = {
+    for volume_snapshot in data.powerstore_volume_snapshot.test1.volumes : volume_snapshot.name => {
+      id = volume_snapshot.id
+      size = volume_snapshot.size
+    }
+  }
 }

--- a/examples/data-sources/powerstore_volumegroup/data-source.tf
+++ b/examples/data-sources/powerstore_volumegroup/data-source.tf
@@ -41,6 +41,22 @@ data "powerstore_volumegroup" "filter" {
   filter_expression = "name=ilike.vg*"
 }
 
-output "volumeGroupResult" {
+# Output all Volume Group Details
+output "volumegroup_all_details" {
   value = data.powerstore_volumegroup.all.volume_groups
+}
+
+# Output only Volume Group names
+output "volume_group_names_only" {
+  value = data.powerstore_volumegroup.all.volume_groups.*.name
+}
+
+# Output Volume Group creation_timestamps and location_history with Volume Group ID as key
+output "volume_group_id_and_size" {
+  value = {
+    for volume_group in data.powerstore_volumegroup.all.volume_groups : volume_group.id => {
+      creation_timestamp  = volume_group.creation_timestamp 
+      location_history  = volume_group.location_history 
+    }
+  }
 }

--- a/examples/data-sources/powerstore_volumegroup_snapshot/data-source.tf
+++ b/examples/data-sources/powerstore_volumegroup_snapshot/data-source.tf
@@ -40,6 +40,23 @@ data "powerstore_volumegroup_snapshot" "filter" {
   filter_expression = "name=ilike.snap"
 }
 
-output "volumeGroupSnapshotResult" {
+# Output all Volume Group Snapshot Details
+output "volumegroupSnapshot_all_details" {
   value = data.powerstore_volumegroup_snapshot.all.volume_groups
+}
+
+
+# Output only Volume Group names
+output "volumeGroupSnapshot_names_only" {
+  value = data.powerstore_volumegroup_snapshot.all.volume_groups.*.name
+}
+
+# Output Volume Group Snapshot creation_timestamps and location_history with Volume Group Snapshot ID as key
+output "volumeGroupSnapshot_id_and_size" {
+  value = {
+    for volume_group in data.powerstore_volumegroup_snapshot.all.volume_groups : volume_group.id => {
+      creation_timestamp  = volume_group.creation_timestamp 
+      location_history  = volume_group.location_history 
+    }
+  }
 }


### PR DESCRIPTION
# Description
Datasources in PowerStore support the fetching of specific fields within the output block. Examples of the same have been added.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken
