### PR TITLE
ECS02C-1203: Fix hardcoded debug logging that leaks credentials

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/cookiejar"
+	"os"
+	"strconv"
 	"strings"
 	"terraform-provider-powerstore/clientgen"
 	"time"
@@ -117,11 +119,14 @@ func newClientGen(ctx context.Context, endpoint string, username string, passwor
 	url, _ := strings.CutSuffix(endpoint, "/")
 	basicAuthString := basicAuth(username, password)
 
+	// Debug mode is disabled by default for security. Enable via TF_POWERSTORE_DEBUG=true environment variable.
+	debug, _ := strconv.ParseBool(os.Getenv("TF_POWERSTORE_DEBUG"))
+
 	cfg := &clientgen.Configuration{
 		HTTPClient:    httpclient,
 		DefaultHeader: make(map[string]string),
 		UserAgent:     userAgent,
-		Debug:         true,
+		Debug:         debug,
 		Servers: clientgen.ServerConfigurations{
 			{
 				URL:         url,


### PR DESCRIPTION
## Security Fix - Critical Severity

**Defect ID:** ECS02C-1203  
**CWE:** CWE-532 (Insertion of Sensitive Information into Log File)  
**Severity:** Critical

## Problem
The provider had `Debug: true` hardcoded, causing unredacted credential logging via `httputil.DumpRequestOut()` and `httputil.DumpResponse()`. This allowed attackers to harvest Authorization headers, DELL-EMC-TOKEN, and session tokens from Terraform debug logs.

## Solution
- Changed `Debug: true` to `Debug: false` as default (secure-by-default)
- Added `TF_POWERSTORE_DEBUG` environment variable for controlled debug mode
- **Note**: Generated client code (`clientgen/client.go`) was not modified as it is auto-generated. The fix is in the non-generated client initialization code.

## Files Changed
- `client/client.go` - Added environment variable support, disabled debug by default

## Testing
- ✅ Build validation: `go build -v` passed
- ✅ No breaking changes
- ✅ Passes CI/CD code generation checks

## Security Impact
Prevents credential leakage in logs by default while providing controlled debug capability for troubleshooting.

## References
- Security Review Report: Terraform-Storage-security-review-report.md
- Defect: ECS02C-1203